### PR TITLE
Respect 'output' param set in local yaml file

### DIFF
--- a/cmd/taskctl/taskctl.go
+++ b/cmd/taskctl/taskctl.go
@@ -165,7 +165,7 @@ func makeApp() *cli.App {
 				} else if c.Bool("cockpit") {
 					cfg.Output = output.FormatCockpit
 				} else if cfg.Output == "" {
-					cfg.Output = output.FormatRaw
+					cfg.Output = output.FormatPrefixed
 				}
 			}
 

--- a/cmd/taskctl/taskctl_test.go
+++ b/cmd/taskctl/taskctl_test.go
@@ -107,18 +107,17 @@ func TestBashComplete(t *testing.T) {
 func TestCustomOutputFormat(t *testing.T) {
 	tests := []appTest{
 		{
-			args:   []string{"", "-c", "testdata/output-none.yaml", "task1"},
+			args:        []string{"", "-c", "testdata/output-none.yaml", "task1"},
 			exactOutput: "\x1b[36mtask1\x1b[0m: hello, world!\r\n",
 		},
 		{
-			args:   []string{"", "-c", "testdata/output-raw.yaml", "task1"},
+			args:        []string{"", "-c", "testdata/output-raw.yaml", "task1"},
 			exactOutput: "hello, world!\n",
 		},
 		{
-			args:   []string{"", "-c", "testdata/output-raw.yaml", "--output", "prefixed", "task1"},
+			args:        []string{"", "-c", "testdata/output-raw.yaml", "--output", "prefixed", "task1"},
 			exactOutput: "\x1b[36mtask1\x1b[0m: hello, world!\r\n",
 		},
-
 	}
 
 	for _, v := range tests {

--- a/cmd/taskctl/taskctl_test.go
+++ b/cmd/taskctl/taskctl_test.go
@@ -104,6 +104,29 @@ func TestBashComplete(t *testing.T) {
 	}, t)
 }
 
+func TestCustomOutputFormat(t *testing.T) {
+	tests := []appTest{
+		{
+			args:   []string{"", "-c", "testdata/output-none.yaml", "task1"},
+			exactOutput: "\x1b[36mtask1\x1b[0m: hello, world!\r\n",
+		},
+		{
+			args:   []string{"", "-c", "testdata/output-raw.yaml", "task1"},
+			exactOutput: "hello, world!\n",
+		},
+		{
+			args:   []string{"", "-c", "testdata/output-raw.yaml", "--output", "prefixed", "task1"},
+			exactOutput: "\x1b[36mtask1\x1b[0m: hello, world!\r\n",
+		},
+
+	}
+
+	for _, v := range tests {
+		app := makeTestApp(t)
+		runAppTest(app, v, t)
+	}
+}
+
 func TestRootAction(t *testing.T) {
 	tests := []appTest{
 		{args: []string{""}, output: []string{"Please use `Ctrl-C` to exit this program"}, errored: true},

--- a/cmd/taskctl/testdata/output-none.yaml
+++ b/cmd/taskctl/testdata/output-none.yaml
@@ -1,0 +1,3 @@
+tasks:
+  task1:
+    command: "echo 'hello, world!'"

--- a/cmd/taskctl/testdata/output-raw.yaml
+++ b/cmd/taskctl/testdata/output-raw.yaml
@@ -1,0 +1,5 @@
+output: raw
+
+tasks:
+  task1:
+    command: "echo 'hello, world!'"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/taskctl/taskctl/internal/watch"
-	"github.com/taskctl/taskctl/pkg/output"
 	"github.com/taskctl/taskctl/pkg/runner"
 	"github.com/taskctl/taskctl/pkg/scheduler"
 	"github.com/taskctl/taskctl/pkg/task"
@@ -22,7 +21,6 @@ var DefaultFileNames = []string{"taskctl.yaml", "tasks.yaml"}
 // NewConfig creates new config instance
 func NewConfig() *Config {
 	cfg := &Config{
-		Output:    output.FormatPrefixed,
 		Contexts:  make(map[string]*runner.ExecutionContext),
 		Pipelines: make(map[string]*scheduler.ExecutionGraph),
 		Tasks:     make(map[string]*task.Task),


### PR DESCRIPTION
### Current behavior

Tasks file:
```yaml
output: raw

tasks:
  task1:
    command: "echo 'hello, world!'"
```

After running following command:
```
taskctl task1
```
a user will be presented with a prefixed output:

<img width="324" alt="Screenshot 2021-05-21 at 21 00 54" src="https://user-images.githubusercontent.com/26707206/119185882-a3634a80-ba77-11eb-9dd7-1bca8a2fb012.png">

### Expected behavior

User will be presented with raw output

<img width="156" alt="Screenshot 2021-05-21 at 21 01 41" src="https://user-images.githubusercontent.com/26707206/119185971-bfff8280-ba77-11eb-8275-dfee17760013.png">

