### PR TITLE
Add env_file to pipelines and context

### DIFF
--- a/internal/config/context_test.go
+++ b/internal/config/context_test.go
@@ -3,10 +3,12 @@ package config
 import (
 	"testing"
 
+	"github.com/taskctl/taskctl/pkg/variables"
+
 	"github.com/taskctl/taskctl/pkg/utils"
 )
 
-func Test_buildContext(t *testing.T) {
+func Test_buildContext_dir(t *testing.T) {
 	c, err := buildContext(&contextDefinition{
 		Up:        []string{"true"},
 		Down:      []string{"true"},
@@ -17,11 +19,28 @@ func Test_buildContext(t *testing.T) {
 		Quote:     "'",
 	})
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	cwd := utils.MustGetwd()
 	if c.Dir != cwd {
 		t.Error()
+	}
+}
+
+func Test_buildContext_env_file(t *testing.T) {
+	c, err := buildContext(&contextDefinition{
+		Env:       map[string]string{},
+		EnvFile:   "testdata/.env",
+		Variables: map[string]string{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for k, v := range variables.FromMap(map[string]string{"VAR_1": "VAL_1_2", "VAR_2": "VAL_2"}).Map() {
+		if c.Env.Get(k) != v {
+			t.Errorf("buildContext() env error, want %s, got %s", v, c.Env.Get(k))
+		}
 	}
 }

--- a/internal/config/definitions.go
+++ b/internal/config/definitions.go
@@ -26,6 +26,7 @@ type stageDefinition struct {
 	AllowFailure bool     `mapstructure:"allow_failure"`
 	Dir          string
 	Env          map[string]string
+	EnvFile      string `mapstructure:"env_file"`
 	Variables    map[string]string
 }
 

--- a/internal/config/pipeline_test.go
+++ b/internal/config/pipeline_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/taskctl/taskctl/pkg/variables"
+
 	"github.com/taskctl/taskctl/pkg/scheduler"
 )
 
@@ -129,5 +131,48 @@ func TestBuildPipeline_Error(t *testing.T) {
 	_, err = buildPipeline(g, stages3, cfg)
 	if err == nil || !strings.Contains(err.Error(), "stage with same name") {
 		t.Error()
+	}
+}
+
+func TestBuildPipeline_env_file(t *testing.T) {
+	cfg := NewConfig()
+
+	stages := []*stageDefinition{
+		{
+			Name:    "task1",
+			Task:    "task1",
+			EnvFile: "./testdata/.env",
+		},
+	}
+
+	tasks := map[string]*taskDefinition{
+		"task1": {
+			Name: "task1",
+		},
+	}
+
+	var err error
+	for k, v := range tasks {
+		cfg.Tasks[k], err = buildTask(v, &loaderContext{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	g, _ := scheduler.NewExecutionGraph()
+	pipeline, err := buildPipeline(g, stages, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stage, err := pipeline.Node("task1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for k, v := range variables.FromMap(map[string]string{"VAR_1": "VAL_1_2", "VAR_2": "VAL_2"}).Map() {
+		if stage.Env.Get(k) != v {
+			t.Errorf("buildContext() env error, want %s, got %s", v, stage.Env.Get(k))
+		}
 	}
 }


### PR DESCRIPTION
### Feature request

`taskctl` is a great tool! However, it is not possible to easily reuse tasks for multiple environments. Especially in cases, where you maintain environment parity, but enumerating all env variables would cause tasks file to grow significantly. It might be easily solved by an ability to specify env_file for specific pipeline and context

```yaml
pipelines:
  live-pipeline1:
    - task: task1
      name: liveStage1
      env_file: .env.live
  stage-pipeline1:
    - task: task1
      name: stageStage1
      env_file: .env.stage

tasks:
  test1:
    command:
      - echo $FOO
```