### PR TITLE
chore: add support for darwin/arm64 in installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,10 +29,10 @@ parse_args() {
   BINDIR=${BINDIR:-./bin}
   while getopts "b:dh?x" arg; do
     case "$arg" in
-      b) BINDIR="$OPTARG" ;;
-      d) log_set_priority 10 ;;
-      h | \?) usage "$0" ;;
-      x) set -x ;;
+    b) BINDIR="$OPTARG" ;;
+    d) log_set_priority 10 ;;
+    h | \?) usage "$0" ;;
+    x) set -x ;;
     esac
   done
   shift $((OPTIND - 1))
@@ -62,15 +62,16 @@ execute() {
 }
 get_binaries() {
   case "$PLATFORM" in
-    darwin/amd64) BINARIES="taskctl" ;;
-    linux/386) BINARIES="taskctl" ;;
-    linux/amd64) BINARIES="taskctl" ;;
-    windows/386) BINARIES="taskctl" ;;
-    windows/amd64) BINARIES="taskctl" ;;
-    *)
-      log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
-      exit 1
-      ;;
+  darwin/amd64) BINARIES="taskctl" ;;
+  darwin/arm64) BINARIES="taskctl" ;;
+  linux/386) BINARIES="taskctl" ;;
+  linux/amd64) BINARIES="taskctl" ;;
+  windows/386) BINARIES="taskctl" ;;
+  windows/amd64) BINARIES="taskctl" ;;
+  *)
+    log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
+    exit 1
+    ;;
   esac
 }
 tag_to_version() {
@@ -91,7 +92,7 @@ tag_to_version() {
 adjust_format() {
   # change format (tar.gz or zip) based on OS
   case ${OS} in
-    windows) FORMAT=zip ;;
+  windows) FORMAT=zip ;;
   esac
   true
 }
@@ -134,15 +135,15 @@ log_priority() {
 }
 log_tag() {
   case $1 in
-    0) echo "emerg" ;;
-    1) echo "alert" ;;
-    2) echo "crit" ;;
-    3) echo "err" ;;
-    4) echo "warning" ;;
-    5) echo "notice" ;;
-    6) echo "info" ;;
-    7) echo "debug" ;;
-    *) echo "$1" ;;
+  0) echo "emerg" ;;
+  1) echo "alert" ;;
+  2) echo "crit" ;;
+  3) echo "err" ;;
+  4) echo "warning" ;;
+  5) echo "notice" ;;
+  6) echo "info" ;;
+  7) echo "debug" ;;
+  *) echo "$1" ;;
   esac
 }
 log_debug() {
@@ -164,40 +165,40 @@ log_crit() {
 uname_os() {
   os=$(uname -s | tr '[:upper:]' '[:lower:]')
   case "$os" in
-    cygwin_nt*) os="windows" ;;
-    mingw*) os="windows" ;;
-    msys_nt*) os="windows" ;;
+  cygwin_nt*) os="windows" ;;
+  mingw*) os="windows" ;;
+  msys_nt*) os="windows" ;;
   esac
   echo "$os"
 }
 uname_arch() {
   arch=$(uname -m)
   case $arch in
-    x86_64) arch="amd64" ;;
-    x86) arch="386" ;;
-    i686) arch="386" ;;
-    i386) arch="386" ;;
-    aarch64) arch="arm64" ;;
-    armv5*) arch="armv5" ;;
-    armv6*) arch="armv6" ;;
-    armv7*) arch="armv7" ;;
+  x86_64) arch="amd64" ;;
+  x86) arch="386" ;;
+  i686) arch="386" ;;
+  i386) arch="386" ;;
+  aarch64) arch="arm64" ;;
+  armv5*) arch="armv5" ;;
+  armv6*) arch="armv6" ;;
+  armv7*) arch="armv7" ;;
   esac
   echo ${arch}
 }
 uname_os_check() {
   os=$(uname_os)
   case "$os" in
-    darwin) return 0 ;;
-    dragonfly) return 0 ;;
-    freebsd) return 0 ;;
-    linux) return 0 ;;
-    android) return 0 ;;
-    nacl) return 0 ;;
-    netbsd) return 0 ;;
-    openbsd) return 0 ;;
-    plan9) return 0 ;;
-    solaris) return 0 ;;
-    windows) return 0 ;;
+  darwin) return 0 ;;
+  dragonfly) return 0 ;;
+  freebsd) return 0 ;;
+  linux) return 0 ;;
+  android) return 0 ;;
+  nacl) return 0 ;;
+  netbsd) return 0 ;;
+  openbsd) return 0 ;;
+  plan9) return 0 ;;
+  solaris) return 0 ;;
+  windows) return 0 ;;
   esac
   log_crit "uname_os_check '$(uname -s)' got converted to '$os' which is not a GOOS value. Please file bug at https://github.com/client9/shlib"
   return 1
@@ -205,20 +206,20 @@ uname_os_check() {
 uname_arch_check() {
   arch=$(uname_arch)
   case "$arch" in
-    386) return 0 ;;
-    amd64) return 0 ;;
-    arm64) return 0 ;;
-    armv5) return 0 ;;
-    armv6) return 0 ;;
-    armv7) return 0 ;;
-    ppc64) return 0 ;;
-    ppc64le) return 0 ;;
-    mips) return 0 ;;
-    mipsle) return 0 ;;
-    mips64) return 0 ;;
-    mips64le) return 0 ;;
-    s390x) return 0 ;;
-    amd64p32) return 0 ;;
+  386) return 0 ;;
+  amd64) return 0 ;;
+  arm64) return 0 ;;
+  armv5) return 0 ;;
+  armv6) return 0 ;;
+  armv7) return 0 ;;
+  ppc64) return 0 ;;
+  ppc64le) return 0 ;;
+  mips) return 0 ;;
+  mipsle) return 0 ;;
+  mips64) return 0 ;;
+  mips64le) return 0 ;;
+  s390x) return 0 ;;
+  amd64p32) return 0 ;;
   esac
   log_crit "uname_arch_check '$(uname -m)' got converted to '$arch' which is not a GOARCH value.  Please file bug report at https://github.com/client9/shlib"
   return 1
@@ -226,13 +227,13 @@ uname_arch_check() {
 untar() {
   tarball=$1
   case "${tarball}" in
-    *.tar.gz | *.tgz) tar --no-same-owner -xzf "${tarball}" ;;
-    *.tar) tar --no-same-owner -xf "${tarball}" ;;
-    *.zip) unzip "${tarball}" ;;
-    *)
-      log_err "untar unknown archive format for ${tarball}"
-      return 1
-      ;;
+  *.tar.gz | *.tgz) tar --no-same-owner -xzf "${tarball}" ;;
+  *.tar) tar --no-same-owner -xf "${tarball}" ;;
+  *.zip) unzip "${tarball}" ;;
+  *)
+    log_err "untar unknown archive format for ${tarball}"
+    return 1
+    ;;
   esac
 }
 http_download_curl() {
@@ -345,7 +346,7 @@ PREFIX="$OWNER/$REPO"
 
 # use in logging routines
 log_prefix() {
-	echo "$PREFIX"
+  echo "$PREFIX"
 }
 PLATFORM="${OS}/${ARCH}"
 GITHUB_DOWNLOAD=https://github.com/${OWNER}/${REPO}/releases/download
@@ -372,6 +373,5 @@ TARBALL=${NAME}.${FORMAT}
 TARBALL_URL=${GITHUB_DOWNLOAD}/${TAG}/${TARBALL}
 CHECKSUM=checksums.txt
 CHECKSUM_URL=${GITHUB_DOWNLOAD}/${TAG}/${CHECKSUM}
-
 
 execute


### PR DESCRIPTION
Currently `darwin/arm64` not supported, and I updated the `install.sh` script to add the support. 