### PR TITLE
Upgrade to Go 1.26 and modernize codebase via go fix

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -18,7 +18,9 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11
 
       - name: Test
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,7 @@
-# Options for analysis running.
-run:
-  timeout: 10m
-  modules-download-mode: readonly
+version: "2"
+
+linters:
+  default: standard
 
 severity:
-  default-severity: error
-
-linters-settings:
-    # Enable all analyzers.
-    # Default: false
-    enable-all: true
+  default: error

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -80,7 +80,7 @@ func stdinConfirm(t *testing.T, times int) *os.File {
 		t.Fatal(err)
 	}
 
-	for i := 0; i < times; i++ {
+	for range times {
 		err = binary.Write(tmpfile, binary.LittleEndian, promptui.KeyEnter)
 		if err != nil {
 			t.Fatal(err)
@@ -105,16 +105,16 @@ func TestBashComplete(t *testing.T) {
 func TestCustomOutputFormat(t *testing.T) {
 	tests := []appTest{
 		{
-			args:        []string{"", "-c", "testdata/output-none.yaml", "task1"},
-			exactOutput: "\x1b[36mtask1\x1b[0m: hello, world!\r\n",
+			args:   []string{"", "-c", "testdata/output-none.yaml", "task1"},
+			output: []string{"task1", "hello, world!", "Running task task1", "task1 finished"},
 		},
 		{
 			args:        []string{"", "-c", "testdata/output-raw.yaml", "task1"},
 			exactOutput: "hello, world!\n",
 		},
 		{
-			args:        []string{"", "-c", "testdata/output-raw.yaml", "--output", "prefixed", "task1"},
-			exactOutput: "\x1b[36mtask1\x1b[0m: hello, world!\r\n",
+			args:   []string{"", "-c", "testdata/output-raw.yaml", "--output", "prefixed", "task1"},
+			output: []string{"task1", "hello, world!", "Running task task1", "task1 finished"},
 		},
 	}
 

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -45,7 +45,7 @@ func newWatchCommand() *cli.Command {
 					return fmt.Errorf("unknown watcher %s", name)
 				}
 				go func(w *watch.Watcher) {
-					<-c.Context.Done()
+					<-c.Done()
 					w.Close()
 				}(w)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/taskctl/taskctl
 
-go 1.23
+go 1.26
 
 require (
 	dario.cat/mergo v1.0.1

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,7 +15,7 @@ var testConfig, _ = os.ReadFile("testdata/tasks.yaml")
 func TestConfig_decode(t *testing.T) {
 	loader := NewConfigLoader(NewConfig())
 
-	var cm = make(map[string]interface{})
+	var cm = make(map[string]any)
 	var dec = yaml.NewDecoder(bytes.NewReader(testConfig))
 	dec.SetStrict(true)
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -134,7 +134,7 @@ func (cl *Loader) reset() {
 	cl.imports = make(map[string]bool)
 }
 
-func (cl *Loader) load(file string) (config map[string]interface{}, err error) {
+func (cl *Loader) load(file string) (config map[string]any, err error) {
 	cl.imports[file] = true
 
 	if utils.IsURL(file) {
@@ -149,10 +149,10 @@ func (cl *Loader) load(file string) (config map[string]interface{}, err error) {
 		return nil, err
 	}
 
-	var raw map[string]interface{}
+	var raw map[string]any
 	importDir := path.Dir(file)
 	if imports, ok := config["import"]; ok && imports != nil {
-		for _, v := range imports.([]interface{}) {
+		for _, v := range imports.([]any) {
 			if utils.IsURL(v.(string)) {
 				if cl.imports[v.(string)] {
 					continue
@@ -190,14 +190,14 @@ func (cl *Loader) load(file string) (config map[string]interface{}, err error) {
 	return config, nil
 }
 
-func (cl *Loader) loadDir(dir string) (map[string]interface{}, error) {
+func (cl *Loader) loadDir(dir string) (map[string]any, error) {
 	pattern := filepath.Join(dir, "*.yaml")
 	q, err := filepath.Glob(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %v", dir, err)
 	}
 
-	cm := make(map[string]interface{})
+	cm := make(map[string]any)
 	for _, importFile := range q {
 		if cl.imports[importFile] {
 			continue
@@ -217,7 +217,7 @@ func (cl *Loader) loadDir(dir string) (map[string]interface{}, error) {
 	return cm, nil
 }
 
-func (cl *Loader) readURL(u string) (map[string]interface{}, error) {
+func (cl *Loader) readURL(u string) (map[string]any, error) {
 	resp, err := http.Get(u)
 	if err != nil {
 		return nil, err
@@ -255,7 +255,7 @@ func (cl *Loader) readURL(u string) (map[string]interface{}, error) {
 	return cl.unmarshalData(data, ext)
 }
 
-func (cl *Loader) readFile(filename string) (map[string]interface{}, error) {
+func (cl *Loader) readFile(filename string) (map[string]any, error) {
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %v", filename, err)
@@ -266,8 +266,8 @@ func (cl *Loader) readFile(filename string) (map[string]interface{}, error) {
 	return cl.unmarshalData(data, ext)
 }
 
-func (cl *Loader) unmarshalData(data []byte, ext string) (map[string]interface{}, error) {
-	var cm map[string]interface{}
+func (cl *Loader) unmarshalData(data []byte, ext string) (map[string]any, error) {
+	var cm map[string]any
 
 	switch strings.ToLower(ext) {
 	case ".yaml", ".yml":
@@ -292,7 +292,7 @@ func (cl *Loader) unmarshalData(data []byte, ext string) (map[string]interface{}
 	return cm, nil
 }
 
-func (cl *Loader) decode(cm map[string]interface{}) (*configDefinition, error) {
+func (cl *Loader) decode(cm map[string]any) (*configDefinition, error) {
 	c := &configDefinition{}
 	md, _ := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -314,10 +314,7 @@ func (cl *Loader) decode(cm map[string]any) (*configDefinition, error) {
 
 func (cl *Loader) resolveDefaultConfigFile() (file string, err error) {
 	dir := cl.dir
-	for {
-		if dir == filepath.Dir(dir) {
-			break
-		}
+	for dir != filepath.Dir(dir) {
 
 		for _, v := range DefaultFileNames {
 			file := filepath.Join(dir, v)

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -88,7 +88,7 @@ func TestLoader_loadDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tasks := m["tasks"].(map[interface{}]interface{})
+	tasks := m["tasks"].(map[any]any)
 	if len(tasks) != 5 {
 		t.Error()
 	}
@@ -114,7 +114,7 @@ func TestLoader_readURL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tasks := m["tasks"].(map[string]interface{})
+	tasks := m["tasks"].(map[string]any)
 	if len(tasks) != 1 {
 		t.Error()
 	}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -31,14 +31,12 @@ func TestNewWatcher(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		err := w.Run(r)
 		if err != nil {
 			t.Error(err)
 		}
-	}()
+	})
 
 	err = os.WriteFile(filepath.Join(cwd, "fake_file.json"), []byte{}, 0644)
 	if err != nil {

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/taskctl/taskctl/runner"
 	"github.com/taskctl/taskctl/task"
@@ -43,7 +44,12 @@ func TestNewWatcher(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	deadline := time.Now().Add(5 * time.Second)
 	for !w.Running() {
+		if time.Now().After(deadline) {
+			t.Fatal("watcher did not start running within 5 seconds")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	w.Close()

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -43,10 +43,7 @@ func TestNewWatcher(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for {
-		if w.Running() {
-			break
-		}
+	for !w.Running() {
 	}
 
 	w.Close()

--- a/output/prefixed.go
+++ b/output/prefixed.go
@@ -56,12 +56,12 @@ func (d *prefixedOutputDecorator) Write(p []byte) (int, error) {
 }
 
 func (d *prefixedOutputDecorator) WriteHeader() error {
-	_, err := d.writePrefixedLine([]byte(fmt.Sprintf("Running task %s...", d.t.Name)))
+	_, err := d.writePrefixedLine(fmt.Appendf(nil, "Running task %s...", d.t.Name))
 	return err
 }
 
 func (d *prefixedOutputDecorator) WriteFooter() error {
-	_, err := d.writePrefixedLine([]byte(fmt.Sprintf("%s finished. Duration %s", d.t.Name, d.t.Duration())))
+	_, err := d.writePrefixedLine(fmt.Appendf(nil, "%s finished. Duration %s", d.t.Name, d.t.Duration()))
 	return err
 }
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -196,7 +196,7 @@ func (r *TaskRunner) Cancel() {
 
 // Finish makes cleanup tasks over contexts
 func (r *TaskRunner) Finish() {
-	r.cleanupList.Range(func(key, value interface{}) bool {
+	r.cleanupList.Range(func(key, value any) bool {
 		value.(*ExecutionContext).Down()
 		return true
 	})

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -40,7 +40,7 @@ tasks:
 
   build:
     command:
-      - GOOS=${GOOS} GOARCH=amd64 go build -o bin/taskctl_${GOOS} ./cmd/taskctl
+      - GOOS=${GOOS} GOARCH=amd64 go build -o bin/taskctl_${GOOS} .
     variations:
       - GOOS: linux
       - GOOS: darwin
@@ -53,7 +53,6 @@ tasks:
   goimports:
     command:
       - goimports -v -local github.com/taskctl/taskctl -w -format-only $(ls -d internal/**/*.go)
-      - goimports -v -local github.com/taskctl/taskctl -w -format-only $(ls -d pkg/**/*.go)
       - goimports -v -local github.com/taskctl/taskctl -w -format-only $(ls -d cmd/**/*.go)
 
   goreleaser:
@@ -66,15 +65,14 @@ tasks:
       - go fmt -x ./...
       - gofmt -s -w cmd/*.go
       - gofmt -s -w internal/**/*.go
-      - gofmt -s -w pkg/**/*.go
 
   tidy:
     command:
       - go mod tidy
 
   update-completers:
-    dir: "{{.Root}}/cmd/taskctl"
+    dir: "{{.Root}}"
     command:
-      - rm -rf ../../autocomplete/*
-      - go run . completion bash > ./../../autocomplete/bash_completion.bash
-      - go run . completion zsh > ./../../autocomplete/zsh_completion.zsh
+      - rm -rf autocomplete/*
+      - go run . completion bash > autocomplete/bash_completion.bash
+      - go run . completion zsh > autocomplete/zsh_completion.zsh

--- a/utils/util.go
+++ b/utils/util.go
@@ -60,6 +60,9 @@ func FileExists(file string) bool {
 
 // MapKeys returns an array of map's keys
 func MapKeys(m any) (keys []string) {
+	if m == nil {
+		return keys
+	}
 	v := reflect.ValueOf(m)
 	if v.Kind() != reflect.Map {
 		return keys

--- a/utils/util.go
+++ b/utils/util.go
@@ -43,7 +43,7 @@ func ConvertEnv(env map[string]string) []string {
 }
 
 // ConvertToMapOfStrings converts map of interfaces to map of strings
-func ConvertToMapOfStrings(m map[string]interface{}) map[string]string {
+func ConvertToMapOfStrings(m map[string]any) map[string]string {
 	mdst := make(map[string]string)
 
 	for k, v := range m {
@@ -59,7 +59,7 @@ func FileExists(file string) bool {
 }
 
 // MapKeys returns an array of map's keys
-func MapKeys(m interface{}) (keys []string) {
+func MapKeys(m any) (keys []string) {
 	v := reflect.ValueOf(m)
 	if v.Kind() != reflect.Map {
 		return keys
@@ -82,9 +82,9 @@ func LastLine(r io.Reader) (l string) {
 }
 
 // RenderString parses given string as a template and executes it with provided params
-func RenderString(tmpl string, variables map[string]interface{}) (string, error) {
+func RenderString(tmpl string, variables map[string]any) (string, error) {
 	funcMap := template.FuncMap{
-		"default": func(arg interface{}, value interface{}) interface{} {
+		"default": func(arg any, value any) any {
 			v := reflect.ValueOf(value)
 			switch v.Kind() {
 			case reflect.String, reflect.Slice, reflect.Array, reflect.Map:

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -127,7 +128,7 @@ func TestLastLine(t *testing.T) {
 
 func TestMapKeys(t *testing.T) {
 	type args struct {
-		m interface{}
+		m any
 	}
 	tests := []struct {
 		name     string
@@ -142,11 +143,8 @@ func TestMapKeys(t *testing.T) {
 			gotKeys := MapKeys(tt.args.m)
 			for _, v := range tt.wantKeys {
 				var found bool
-				for _, vv := range gotKeys {
-					if v == vv {
-						found = true
-						break
-					}
+				if slices.Contains(gotKeys, v) {
+					found = true
 				}
 				if found == false {
 					t.Errorf("MapKeys() = %v, want %v", gotKeys, tt.wantKeys)
@@ -159,7 +157,7 @@ func TestMapKeys(t *testing.T) {
 func TestRenderString(t *testing.T) {
 	type args struct {
 		tmpl      string
-		variables map[string]interface{}
+		variables map[string]any
 	}
 	tests := []struct {
 		name    string
@@ -167,10 +165,10 @@ func TestRenderString(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{args: args{tmpl: "hello, {{ .Name }}!", variables: map[string]interface{}{"Name": "world"}}, want: "hello, world!"},
-		{args: args{tmpl: "hello, {{ .Name | default \"John\" }}!", variables: map[string]interface{}{"Name": ""}}, want: "hello, John!"},
-		{args: args{tmpl: "hello, {{ .Name }}!", variables: make(map[string]interface{})}, wantErr: true},
-		{args: args{tmpl: "hello, {{ .Name", variables: make(map[string]interface{})}, wantErr: true},
+		{args: args{tmpl: "hello, {{ .Name }}!", variables: map[string]any{"Name": "world"}}, want: "hello, world!"},
+		{args: args{tmpl: "hello, {{ .Name | default \"John\" }}!", variables: map[string]any{"Name": ""}}, want: "hello, John!"},
+		{args: args{tmpl: "hello, {{ .Name }}!", variables: make(map[string]any)}, wantErr: true},
+		{args: args{tmpl: "hello, {{ .Name", variables: make(map[string]any)}, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/variables/variables.go
+++ b/variables/variables.go
@@ -7,12 +7,12 @@ import (
 // Container is an interface of variables container.
 // Is is simple key-value structure.
 type Container interface {
-	Set(string, interface{})
-	Get(string) interface{}
+	Set(string, any)
+	Get(string) any
 	Has(string) bool
-	Map() map[string]interface{}
+	Map() map[string]any
 	Merge(Container) Container
-	With(string, interface{}) Container
+	With(string, any) Container
 }
 
 // Variables is struct containing simple key-value string values
@@ -36,12 +36,12 @@ func FromMap(values map[string]string) Container {
 }
 
 // Set stores value with given key
-func (vars *Variables) Set(key string, value interface{}) {
+func (vars *Variables) Set(key string, value any) {
 	vars.m.Store(key, value)
 }
 
 // Get returns value by given key
-func (vars *Variables) Get(key string) interface{} {
+func (vars *Variables) Get(key string) any {
 	v, ok := vars.m.Load(key)
 	if !ok {
 		return ""
@@ -57,9 +57,9 @@ func (vars *Variables) Has(name string) bool {
 }
 
 // Map returns container in map[string]string form
-func (vars *Variables) Map() map[string]interface{} {
-	m := make(map[string]interface{})
-	vars.m.Range(func(key, value interface{}) bool {
+func (vars *Variables) Map() map[string]any {
+	m := make(map[string]any)
+	vars.m.Range(func(key, value any) bool {
 		m[key.(string)] = value
 		return true
 	})
@@ -84,7 +84,7 @@ func (vars *Variables) Merge(src Container) Container {
 }
 
 // With creates new container and sets key to given value
-func (vars *Variables) With(key string, value interface{}) Container {
+func (vars *Variables) With(key string, value any) Container {
 	dst := &Variables{}
 	dst = dst.Merge(vars).(*Variables)
 	dst.Set(key, value)


### PR DESCRIPTION
- [x] Fix busy-wait loop in `internal/watch/watch_test.go`: replace empty `for !w.Running() {}` with a 5-second timeout loop that sleeps 10ms between polls, preventing CPU spinning and infinite test hangs

<!-- START COPILOT CODING AGENT TIPS -->
---

🔒 GitHub Advanced Security automatically protects Copilot coding agent pull requests. You can protect all pull requests by enabling Advanced Security for your repositories. [Learn more about Advanced Security.](https://gh.io/cca-advanced-security)