### PR TITLE
Apply generics: remove type-erasure, adopt slices/maps stdlib

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/signal"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -311,8 +310,8 @@ func buildSuggestions(cfg *config.Config) []suggestion {
 		})
 	}
 
-	sort.Slice(suggestions, func(i, j int) bool {
-		return suggestions[j].Target > suggestions[i].Target
+	slices.SortFunc(suggestions, func(a, b suggestion) int {
+		return strings.Compare(a.Target, b.Target)
 	})
 
 	return suggestions

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -171,13 +172,10 @@ func taskArgs(c *cli.Context) []string {
 }
 
 func printSummary(g *scheduler.ExecutionGraph) {
-	var stages = make([]*scheduler.Stage, 0)
-	for _, stage := range g.Nodes() {
-		stages = append(stages, stage)
-	}
+	stages := slices.Collect(maps.Values(g.Nodes()))
 
-	sort.Slice(stages, func(i, j int) bool {
-		return stages[j].Start.Nanosecond() > stages[i].Start.Nanosecond()
+	slices.SortFunc(stages, func(a, b *scheduler.Stage) int {
+		return a.Start.Compare(b.Start)
 	})
 
 	_, _ = fmt.Fprintln(os.Stdout, aurora.Bold("Summary:").String())

--- a/internal/collections/collections_test.go
+++ b/internal/collections/collections_test.go
@@ -1,0 +1,80 @@
+package collections
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestSet(t *testing.T) {
+	s := NewSet[string]()
+
+	if s.Has("a") {
+		t.Fatal("empty set should not contain a")
+	}
+	if s.Len() != 0 {
+		t.Fatalf("empty set len = %d, want 0", s.Len())
+	}
+
+	s.Add("a")
+	s.Add("a") // idempotent
+	s.Add("b")
+
+	if !s.Has("a") || !s.Has("b") {
+		t.Fatal("set should contain added values")
+	}
+	if s.Has("c") {
+		t.Fatal("set should not contain c")
+	}
+	if s.Len() != 2 {
+		t.Fatalf("set len = %d, want 2", s.Len())
+	}
+}
+
+func TestSyncMapStoreLoad(t *testing.T) {
+	var sm SyncMap[string, int]
+
+	if v, ok := sm.Load("missing"); ok || v != 0 {
+		t.Fatalf("Load(missing) = (%d, %v), want (0, false)", v, ok)
+	}
+
+	sm.Store("x", 42)
+	v, ok := sm.Load("x")
+	if !ok || v != 42 {
+		t.Fatalf("Load(x) = (%d, %v), want (42, true)", v, ok)
+	}
+}
+
+func TestSyncMapRange(t *testing.T) {
+	var sm SyncMap[string, int]
+	sm.Store("a", 1)
+	sm.Store("b", 2)
+	sm.Store("c", 3)
+
+	got := make(map[string]int)
+	sm.Range(func(k string, v int) bool {
+		got[k] = v
+		return true
+	})
+
+	if len(got) != 3 || got["a"] != 1 || got["b"] != 2 || got["c"] != 3 {
+		t.Fatalf("Range collected %v, want a=1,b=2,c=3", got)
+	}
+}
+
+func TestSyncMapRangeEarlyStop(t *testing.T) {
+	var sm SyncMap[string, int]
+	sm.Store("a", 1)
+	sm.Store("b", 2)
+	sm.Store("c", 3)
+
+	var visited []string
+	sm.Range(func(k string, v int) bool {
+		visited = append(visited, k)
+		return false // stop after first
+	})
+
+	if len(visited) != 1 {
+		sort.Strings(visited)
+		t.Fatalf("Range visited %v, want exactly one key", visited)
+	}
+}

--- a/internal/collections/set.go
+++ b/internal/collections/set.go
@@ -1,0 +1,28 @@
+// Package collections provides small generic container types.
+package collections
+
+// Set is a generic set of comparable values. It is not safe for concurrent use.
+type Set[T comparable] struct {
+	m map[T]struct{}
+}
+
+// NewSet creates an empty Set.
+func NewSet[T comparable]() *Set[T] {
+	return &Set[T]{m: make(map[T]struct{})}
+}
+
+// Add inserts v into the set.
+func (s *Set[T]) Add(v T) {
+	s.m[v] = struct{}{}
+}
+
+// Has reports whether v is present in the set.
+func (s *Set[T]) Has(v T) bool {
+	_, ok := s.m[v]
+	return ok
+}
+
+// Len returns the number of elements in the set.
+func (s *Set[T]) Len() int {
+	return len(s.m)
+}

--- a/internal/collections/syncmap.go
+++ b/internal/collections/syncmap.go
@@ -2,10 +2,17 @@ package collections
 
 import "sync"
 
+// noCopy is used to help go vet detect unintended copies of types that must not
+// be copied after first use.
+type noCopy struct{}
+
+func (*noCopy) Lock() {}
+
 // SyncMap is a type-safe wrapper around sync.Map. Like sync.Map it must not be
 // copied after first use; use it via a pointer or as a non-copied struct field.
 type SyncMap[K comparable, V any] struct {
-	m sync.Map
+	noCopy noCopy
+	m      sync.Map
 }
 
 // Store sets the value for a key.

--- a/internal/collections/syncmap.go
+++ b/internal/collections/syncmap.go
@@ -1,0 +1,32 @@
+package collections
+
+import "sync"
+
+// SyncMap is a type-safe wrapper around sync.Map. Like sync.Map it must not be
+// copied after first use; use it via a pointer or as a non-copied struct field.
+type SyncMap[K comparable, V any] struct {
+	m sync.Map
+}
+
+// Store sets the value for a key.
+func (sm *SyncMap[K, V]) Store(k K, v V) {
+	sm.m.Store(k, v)
+}
+
+// Load returns the value stored for a key. The second result reports whether the
+// key was present; on miss the zero value of V is returned.
+func (sm *SyncMap[K, V]) Load(k K) (V, bool) {
+	v, ok := sm.m.Load(k)
+	if !ok {
+		var zero V
+		return zero, false
+	}
+	return v.(V), true
+}
+
+// Range calls f for each key/value pair in the map, stopping if f returns false.
+func (sm *SyncMap[K, V]) Range(f func(k K, v V) bool) {
+	sm.m.Range(func(k, v any) bool {
+		return f(k.(K), v.(V))
+	})
+}

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bmatcuk/doublestar"
 	"github.com/fsnotify/fsnotify"
 
+	"github.com/taskctl/taskctl/internal/collections"
 	"github.com/taskctl/taskctl/runner"
 	"github.com/taskctl/taskctl/task"
 )
@@ -38,7 +39,7 @@ type Watcher struct {
 	r        *runner.TaskRunner
 	finished chan struct{}
 	paths    []string
-	events   map[string]bool
+	events   *collections.Set[string]
 	task     *task.Task
 	fsw      *fsnotify.Watcher
 	closed   chan struct{}
@@ -57,7 +58,7 @@ func NewWatcher(name string, events, watch, exclude []string, t *task.Task) (w *
 		finished: make(chan struct{}),
 		closed:   make(chan struct{}),
 		task:     t,
-		events:   make(map[string]bool),
+		events:   collections.NewSet[string](),
 	}
 
 	w.fsw, err = fsnotify.NewWatcher()
@@ -96,7 +97,7 @@ func NewWatcher(name string, events, watch, exclude []string, t *task.Task) (w *
 	}
 
 	for _, e := range events {
-		w.events[e] = true
+		w.events.Add(e)
 	}
 
 	return w, nil
@@ -188,7 +189,7 @@ func (w *Watcher) handle(event fsnotify.Event) {
 	defer w.eventsWg.Done()
 
 	eventName := fsnotifyMap[event.Op]
-	if !w.events[eventName] {
+	if !w.events.Has(eventName) {
 		return
 	}
 

--- a/output/cockpit.go
+++ b/output/cockpit.go
@@ -3,6 +3,7 @@ package output
 import (
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -78,11 +79,9 @@ func (b *baseCockpit) remove(t *task.Task) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	for k, v := range b.tasks {
-		if v == t {
-			b.tasks = append(b.tasks[:k], b.tasks[k+1:]...)
-		}
-	}
+	b.tasks = slices.DeleteFunc(b.tasks, func(x *task.Task) bool {
+		return x == t
+	})
 
 	var mark = aurora.Green("✔")
 	if t.Errored {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/text/cases"
 
 	"github.com/taskctl/taskctl/executor"
+	"github.com/taskctl/taskctl/internal/collections"
 
 	"github.com/taskctl/taskctl/variables"
 
@@ -51,7 +52,7 @@ type TaskRunner struct {
 	Stdout, Stderr io.Writer
 	OutputFormat   string
 
-	cleanupList sync.Map
+	cleanupList collections.SyncMap[string, *ExecutionContext]
 }
 
 // NewTaskRunner creates new TaskRunner instance
@@ -196,8 +197,8 @@ func (r *TaskRunner) Cancel() {
 
 // Finish makes cleanup tasks over contexts
 func (r *TaskRunner) Finish() {
-	r.cleanupList.Range(func(key, value any) bool {
-		value.(*ExecutionContext).Down()
+	r.cleanupList.Range(func(key string, value *ExecutionContext) bool {
+		value.Down()
 		return true
 	})
 	output.Close()

--- a/scheduler/graph.go
+++ b/scheduler/graph.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/taskctl/taskctl/internal/collections"
 )
 
 // ErrCycleDetected occurs when added edge causes cycle to appear
@@ -64,7 +66,7 @@ func (g *ExecutionGraph) addEdge(from string, to string) error {
 	g.from[from] = append(g.from[from], to)
 	g.to[to] = append(g.to[to], from)
 
-	if err := g.cycleDfs(to, make(map[string]bool)); err != nil {
+	if err := g.cycleDfs(to, collections.NewSet[string]()); err != nil {
 		return err
 	}
 
@@ -96,11 +98,11 @@ func (g *ExecutionGraph) To(name string) []string {
 	return g.to[name]
 }
 
-func (g *ExecutionGraph) cycleDfs(t string, visited map[string]bool) error {
-	if visited[t] {
+func (g *ExecutionGraph) cycleDfs(t string, visited *collections.Set[string]) error {
+	if visited.Has(t) {
 		return ErrCycleDetected
 	}
-	visited[t] = true
+	visited.Add(t)
 
 	for _, next := range g.from[t] {
 		err := g.cycleDfs(next, visited)

--- a/variables/variables.go
+++ b/variables/variables.go
@@ -1,7 +1,7 @@
 package variables
 
 import (
-	"sync"
+	"github.com/taskctl/taskctl/internal/collections"
 )
 
 // Container is an interface of variables container.
@@ -17,7 +17,7 @@ type Container interface {
 
 // Variables is struct containing simple key-value string values
 type Variables struct {
-	m sync.Map
+	m collections.SyncMap[string, any]
 }
 
 // NewVariables creates new Variables instance
@@ -59,8 +59,8 @@ func (vars *Variables) Has(name string) bool {
 // Map returns container in map[string]string form
 func (vars *Variables) Map() map[string]any {
 	m := make(map[string]any)
-	vars.m.Range(func(key, value any) bool {
-		m[key.(string)] = value
+	vars.m.Range(func(key string, value any) bool {
+		m[key] = value
 		return true
 	})
 	return m


### PR DESCRIPTION
## Summary

taskctl was written before Go generics; the module is now `go 1.26`, so `slices`/`maps`/`cmp` and full generics are available. This applies them where they remove type-erasure and duplicated idioms, and leaves genuinely dynamic `any` (config document tree, `text/template` inputs) untouched.

### New package `internal/collections`
- **`Set[T comparable]`** — `Add`/`Has`/`Len`, backed by `map[T]struct{}`.
- **`SyncMap[K comparable, V any]`** — a type-safe wrapper around `sync.Map` (`Store`/`Load`/`Range`). The single unavoidable `k.(K)`/`v.(V)` assertion lives here, exercised by the package's own tests, so call sites become assertion-free.

### Adoption
| File | Before | After |
|------|--------|-------|
| `scheduler/graph.go` | `map[string]bool` visited-set | `*collections.Set[string]` |
| `internal/watch/watch.go` | `map[string]bool` events set | `*collections.Set[string]` |
| `runner/runner.go` | `sync.Map` + `value.(*ExecutionContext)` | `SyncMap[string, *ExecutionContext]` |
| `variables/variables.go` | `sync.Map` + `key.(string)` | `SyncMap[string, any]` |
| `cmd/run.go`, `cmd/cmd.go` | `sort.Slice` | `slices.SortFunc` |
| `output/cockpit.go` | manual index-delete loop | `slices.DeleteFunc` |

### Latent bugs fixed along the way
- **`cmd/run.go` `printSummary`** sorted stages on `Start.Nanosecond()` — only the sub-second component — so stages were mis-ordered across second boundaries. Now uses `time.Time.Compare`.
- **`output/cockpit.go` `remove`** mutated `b.tasks` while ranging it, which can index-skip. `slices.DeleteFunc` removes all matches safely in one pass.

## Out of scope / deferred
`variables.Container` keeps its `any`-valued public API. Converting it to a generic `Container[V]` is the highest-payoff remaining change but touches core data flow (the config loader feeds heterogeneous values), so it's left as separate follow-up work.

## Verification
- `go build ./...`, `go vet ./...` (copylocks clean — no accidental `SyncMap` copies), `go test ./...` → **73 pass**.
- `golangci-lint run` → **0 issues**; `gofmt` clean.
- End-to-end: ran the `build` task and the `prepare` pipeline via a freshly compiled binary — DAG scheduling, `SyncMap` cleanup, and the fixed summary sort all exercised without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)