### PR TITLE
fix(executor): apply per-variation environment when running task jobs

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"os"
+	"slices"
 	"strings"
 
 	"mvdan.cc/sh/v3/expand"
@@ -28,8 +30,20 @@ type Executor interface {
 type DefaultExecutor struct {
 	dir    string
 	env    []string
-	interp *interp.Runner
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
 	buf    bytes.Buffer
+
+	// interp is reused across consecutive jobs sharing the same environment so
+	// that shell state (functions, variables, cwd) set by one command is
+	// visible to the next. lastEnv records the environment it was built with;
+	// when a job's environment differs (e.g. the next task variation) a fresh
+	// interpreter is created — interp.Runner snapshots its environment on first
+	// Run and ignores later Env mutations, so reuse alone would leak the first
+	// job's environment into every subsequent variation.
+	interp  *interp.Runner
+	lastEnv map[string]string
 }
 
 // NewDefaultExecutor creates new default executor
@@ -52,12 +66,9 @@ func NewDefaultExecutor(stdin io.Reader, stdout, stderr io.Writer) (*DefaultExec
 		stderr = io.Discard
 	}
 
-	e.interp, err = interp.New(
-		interp.StdIO(stdin, io.MultiWriter(&e.buf, stdout), io.MultiWriter(&e.buf, stderr)),
-	)
-	if err != nil {
-		return nil, err
-	}
+	e.stdin = stdin
+	e.stdout = io.MultiWriter(&e.buf, stdout)
+	e.stderr = io.MultiWriter(&e.buf, stderr)
 
 	return e, nil
 }
@@ -75,8 +86,7 @@ func (e *DefaultExecutor) Execute(ctx context.Context, job *Job) ([]byte, error)
 		return nil, err
 	}
 
-	env := e.env
-	env = append(env, envutil.ConvertEnv(envutil.ConvertToMapOfStrings(job.Env.Map()))...)
+	jobEnv := envutil.ConvertToMapOfStrings(job.Env.Map())
 
 	if job.Dir == "" {
 		job.Dir = e.dir
@@ -84,8 +94,22 @@ func (e *DefaultExecutor) Execute(ctx context.Context, job *Job) ([]byte, error)
 
 	slog.Debug(fmt.Sprintf("Executing \"%s\"", command))
 
-	e.interp.Dir = job.Dir
-	e.interp.Env = expand.ListEnviron(env...)
+	// Reuse the interpreter while the environment is unchanged so shell state
+	// (functions, variables, cwd) carries across a task's commands; rebuild it
+	// when the environment changes (a new variation) so each variation runs
+	// with its own environment and a clean state.
+	if e.interp == nil || !maps.Equal(jobEnv, e.lastEnv) {
+		env := append(slices.Clone(e.env), envutil.ConvertEnv(jobEnv)...)
+		e.interp, err = interp.New(
+			interp.StdIO(e.stdin, e.stdout, e.stderr),
+			interp.Dir(job.Dir),
+			interp.Env(expand.ListEnviron(env...)),
+		)
+		if err != nil {
+			return nil, err
+		}
+		e.lastEnv = jobEnv
+	}
 
 	var cancelFn context.CancelFunc
 	if job.Timeout != nil {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -35,15 +35,17 @@ type DefaultExecutor struct {
 	stderr io.Writer
 	buf    bytes.Buffer
 
-	// interp is reused across consecutive jobs sharing the same environment so
-	// that shell state (functions, variables, cwd) set by one command is
-	// visible to the next. lastEnv records the environment it was built with;
-	// when a job's environment differs (e.g. the next task variation) a fresh
-	// interpreter is created — interp.Runner snapshots its environment on first
-	// Run and ignores later Env mutations, so reuse alone would leak the first
-	// job's environment into every subsequent variation.
+	// interp is reused across consecutive jobs sharing the same environment and
+	// directory so that shell state (functions, variables, cwd) set by one
+	// command is visible to the next. lastEnv/lastDir record what it was built
+	// with; when a job's environment or directory differs (e.g. the next task
+	// variation) a fresh interpreter is created — interp.Runner snapshots its
+	// environment and directory on first Run and ignores later Env/Dir
+	// mutations, so reuse alone would leak the first job's environment into
+	// every subsequent variation.
 	interp  *interp.Runner
 	lastEnv map[string]string
+	lastDir string
 }
 
 // NewDefaultExecutor creates new default executor
@@ -94,11 +96,11 @@ func (e *DefaultExecutor) Execute(ctx context.Context, job *Job) ([]byte, error)
 
 	slog.Debug(fmt.Sprintf("Executing \"%s\"", command))
 
-	// Reuse the interpreter while the environment is unchanged so shell state
-	// (functions, variables, cwd) carries across a task's commands; rebuild it
-	// when the environment changes (a new variation) so each variation runs
-	// with its own environment and a clean state.
-	if e.interp == nil || !maps.Equal(jobEnv, e.lastEnv) {
+	// Reuse the interpreter while the environment and directory are unchanged so
+	// shell state (functions, variables, cwd) carries across a task's commands;
+	// rebuild it when either changes (a new variation) so each variation runs
+	// with its own environment/directory and a clean state.
+	if e.interp == nil || job.Dir != e.lastDir || !maps.Equal(jobEnv, e.lastEnv) {
 		env := append(slices.Clone(e.env), envutil.ConvertEnv(jobEnv)...)
 		e.interp, err = interp.New(
 			interp.StdIO(e.stdin, e.stdout, e.stderr),
@@ -109,6 +111,7 @@ func (e *DefaultExecutor) Execute(ctx context.Context, job *Job) ([]byte, error)
 			return nil, err
 		}
 		e.lastEnv = jobEnv
+		e.lastDir = job.Dir
 	}
 
 	var cancelFn context.CancelFunc

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/taskctl/taskctl/variables"
 )
 
 func TestDefaultExecutor_Execute(t *testing.T) {
@@ -48,5 +51,54 @@ func TestDefaultExecutor_Execute(t *testing.T) {
 	_, err = e.Execute(context.Background(), job3)
 	if err != nil {
 		t.Error()
+	}
+}
+
+// TestDefaultExecutor_Execute_PerJobEnv guards against the interpreter caching
+// its environment across jobs. A single executor runs the commands of a task's
+// linked list (one per command/variation), so each Execute must honor its own
+// job.Env rather than reusing the first job's environment.
+func TestDefaultExecutor_Execute_PerJobEnv(t *testing.T) {
+	e, err := NewDefaultExecutor(nil, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"linux", "darwin", "windows"} {
+		job := NewJobFromCommand("echo ${GOOS}")
+		job.Env = variables.FromMap(map[string]string{"GOOS": want})
+
+		out, err := e.Execute(context.Background(), job)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got := strings.TrimSpace(string(out)); got != want {
+			t.Errorf("GOOS in command output = %q, want %q", got, want)
+		}
+	}
+}
+
+// TestDefaultExecutor_Execute_SharedShellState verifies that consecutive
+// commands sharing the same environment keep shell state: a function defined by
+// one command must be callable by the next (the executor reuses its
+// interpreter while the environment is unchanged).
+func TestDefaultExecutor_Execute_SharedShellState(t *testing.T) {
+	e, err := NewDefaultExecutor(nil, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := e.Execute(context.Background(), NewJobFromCommand(`function greet() { echo "BBB"; }`)); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := e.Execute(context.Background(), NewJobFromCommand("greet"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := strings.TrimSpace(string(out)); got != "BBB" {
+		t.Errorf("output = %q, want %q", got, "BBB")
 	}
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -102,3 +102,30 @@ func TestDefaultExecutor_Execute_SharedShellState(t *testing.T) {
 		t.Errorf("output = %q, want %q", got, "BBB")
 	}
 }
+
+// TestDefaultExecutor_Execute_PerJobDir verifies that a job's working directory
+// is honored even when a same-env job ran before it: the interpreter must be
+// rebuilt when job.Dir changes rather than reusing the previous directory.
+func TestDefaultExecutor_Execute_PerJobDir(t *testing.T) {
+	e, err := NewDefaultExecutor(nil, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+
+	for _, want := range []string{dirA, dirB} {
+		job := NewJobFromCommand("pwd")
+		job.Dir = want
+
+		out, err := e.Execute(context.Background(), job)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got := strings.TrimSpace(string(out)); got != want {
+			t.Errorf("pwd = %q, want %q", got, want)
+		}
+	}
+}

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1,17 +1,5 @@
 output: cockpit
 pipelines:
-  build:
-    - name: Build "darwin"
-      task: build
-      env:
-        GOOS: darwin
-        BIN_OUT: bin/taskctl_darwin_amd64
-    - name: Build "linux"
-      task: build
-      env:
-        GOOS: linux
-        BIN_OUT: bin/taskctl_linux_amd64
-
   fixcs:
     - task: goimports
       dir: "{{.Root}}"


### PR DESCRIPTION
## Problem

Running the `build` pipeline/task produced **only** `bin/taskctl_linux`, even though the `build` task declares three `variations` (`GOOS` = linux/darwin/windows).

## Root cause

`DefaultExecutor` reused a single `mvdan.cc/sh` `interp.Runner` across every job in a task's command list. `interp.Runner` snapshots its environment on the **first** `Run` (inside `Reset()`, guarded by `if !r.didReset`) and ignores later `Env` reassignment. So every command — including every variation — ran with the **first** job's environment. All three variations executed as `GOOS=linux`, overwriting a single binary.

Verified with instrumentation: the per-job env slice reaching the interpreter was correct (`GOOS=darwin`, `GOOS=windows`), but the shell still resolved `linux` every time.

## Why not just create a fresh interpreter per job

The reuse is **load-bearing**: commands within a task share shell state (`TestTaskRunner` defines a shell function in command 1 and calls it in command 2). A fresh interpreter per job breaks that (`exit 127`).

## Fix

The compiler flattens `commands × variations` into one job list where the environment is constant within a variation and only changes at variation boundaries. So: reuse the interpreter while `job.Env` is unchanged (`maps.Equal`), and rebuild it (via `interp.New` with `interp.Env`/`interp.Dir` options) when the env changes — i.e. **one interpreter per variation**. This preserves intra-variation shell continuity while giving each variation its own environment. Also stopped aliasing `os.Environ()`'s backing array (`slices.Clone`).

`tasks.yaml`: dropped the two redundant `build` pipeline stages — their per-stage `GOOS` was silently overridden by the task's variations, and `BIN_OUT` was never referenced.

## Tests

- New `TestDefaultExecutor_Execute_PerJobEnv` — per-variation env isolation (fails without the fix).
- New `TestDefaultExecutor_Execute_SharedShellState` — function defined in one command callable by the next.
- `go test -race ./...` → 75 passed; `golangci-lint run` → clean.
- `taskctl build` now emits `taskctl_darwin`, `taskctl_linux`, `taskctl_windows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)