### PR TITLE
fix: drop invalid Cygwin/Windows env entries (#100)

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -52,7 +52,7 @@ type DefaultExecutor struct {
 func NewDefaultExecutor(stdin io.Reader, stdout, stderr io.Writer) (*DefaultExecutor, error) {
 	var err error
 	e := &DefaultExecutor{
-		env: os.Environ(),
+		env: envutil.SanitizeEnviron(os.Environ()),
 	}
 
 	e.dir, err = os.Getwd()

--- a/internal/envutil/envutil.go
+++ b/internal/envutil/envutil.go
@@ -32,6 +32,32 @@ func ConvertToMapOfStrings(m map[string]any) map[string]string {
 	return mdst
 }
 
+// SanitizeEnviron filters out entries with invalid variable names, such as
+// Cygwin's "!::=::\" or Windows' hidden "=C:=C:\dir" drive entries.
+//
+// Only the first character is checked (letter or underscore) rather than the
+// full POSIX name (e.g. syntax.ValidName): this deliberately keeps legitimate
+// Windows variables like "ProgramFiles(x86)" that child processes may need,
+// while still dropping the OS-generated junk above.
+func SanitizeEnviron(environ []string) []string {
+	sanitized := make([]string, 0, len(environ))
+	for _, entry := range environ {
+		key, _, found := strings.Cut(entry, "=")
+		if !found || key == "" || !isNameStart(key[0]) {
+			continue
+		}
+		sanitized = append(sanitized, entry)
+	}
+
+	return sanitized
+}
+
+// isNameStart reports whether b is a valid first character of an environment
+// variable name (an ASCII letter or underscore).
+func isNameStart(b byte) bool {
+	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
 // ReadEnvFile reads env file in `k=v` format
 func ReadEnvFile(filename string) (map[string]string, error) {
 	f, err := os.Open(filename)

--- a/internal/envutil/envutil_test.go
+++ b/internal/envutil/envutil_test.go
@@ -51,6 +51,73 @@ func TestReadEnvFile(t *testing.T) {
 	}
 }
 
+func TestSanitizeEnviron(t *testing.T) {
+	type args struct {
+		environ []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "normal var kept",
+			args: args{environ: []string{"PATH=/usr/bin"}},
+			want: []string{"PATH=/usr/bin"},
+		},
+		{
+			name: "underscore-first kept",
+			args: args{environ: []string{"_UNDERSCORE=x"}},
+			want: []string{"_UNDERSCORE=x"},
+		},
+		{
+			name: "windows var with parens kept",
+			args: args{environ: []string{"ProgramFiles(x86)=C:\\Program Files (x86)"}},
+			want: []string{"ProgramFiles(x86)=C:\\Program Files (x86)"},
+		},
+		{
+			name: "cygwin junk dropped",
+			args: args{environ: []string{"!::=::\\"}},
+			want: []string{},
+		},
+		{
+			name: "windows hidden drive entry dropped (empty key)",
+			args: args{environ: []string{"=C:=C:\\foo"}},
+			want: []string{},
+		},
+		{
+			name: "no-equals dropped",
+			args: args{environ: []string{"NOEQUALS"}},
+			want: []string{},
+		},
+		{
+			name: "empty string dropped",
+			args: args{environ: []string{""}},
+			want: []string{},
+		},
+		{
+			name: "mixed input preserves order and drops invalid entries",
+			args: args{environ: []string{
+				"PATH=/usr/bin",
+				"!::=::\\",
+				"=C:=C:\\foo",
+				"HOME=/home/user",
+				"NOEQUALS",
+				"_OK=1",
+				"",
+			}},
+			want: []string{"PATH=/usr/bin", "HOME=/home/user", "_OK=1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SanitizeEnviron(tt.args.environ); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SanitizeEnviron() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestReadEnvFile_notExist(t *testing.T) {
 	if _, err := ReadEnvFile(filepath.Join(t.TempDir(), "missing.env")); err == nil {
 		t.Error("expected error for missing file, got nil")


### PR DESCRIPTION
## Overview

On Cygwin/MSYS (and Windows) terminals, taskctl leaked pseudo-environment entries with invalid variable names into task environments and any child processes they spawned. The reported symptom (issue #100) was Cygwin's `!::=::\` entry ending up where a Docker container couldn't accept it.

## Root cause

`executor.NewDefaultExecutor` captured `os.Environ()` verbatim and fed every entry into the embedded `mvdan.cc/sh` interpreter, which passes them down to child processes. On these platforms `os.Environ()` contains OS-generated junk that isn't a valid variable at all:

- Cygwin/MSYS drive-tracking var `!::=::\` (name `!::`)
- Windows hidden per-drive-cwd entries like `=C:=C:\dir` (empty name)

`expand.ListEnviron` already discards the empty-name / no-`=` cases downstream, but it does **not** validate name characters — so `!::` sailed through to child processes.

## Decisions

- **Sanitize once, at the executor boundary** (`envutil.SanitizeEnviron(os.Environ())`) rather than in `ConvertEnv`/`ReadEnvFile`, which handle user-authored config values, not inherited OS junk.
- **Lenient first-character rule** (name must start with an ASCII letter or `_`), not the strict POSIX `syntax.ValidName`. The strict rule would also drop legitimate Windows vars such as `ProgramFiles(x86)` that child processes may genuinely need; the first-char check is sufficient to reject the observed junk while preserving those.

## Fix

- `internal/envutil/envutil.go`: add `SanitizeEnviron` (+ `isNameStart` helper), with a doc comment recording why the lenient rule is intentional.
- `executor/executor.go`: `NewDefaultExecutor` now sanitizes `os.Environ()`.
- `internal/envutil/envutil_test.go`: `TestSanitizeEnviron` covering the junk cases, `ProgramFiles(x86)` preservation, and order.

No config surface, CLI flags, or public schema changed. `docs-sync` confirmed no documentation drift.

Fixes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)