### PR TITLE
fix: task env overrides inherited OS vars (#88)

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"maps"
 	"os"
-	"slices"
 	"strings"
 
 	"mvdan.cc/sh/v3/expand"
@@ -101,7 +100,7 @@ func (e *DefaultExecutor) Execute(ctx context.Context, job *Job) ([]byte, error)
 	// rebuild it when either changes (a new variation) so each variation runs
 	// with its own environment/directory and a clean state.
 	if e.interp == nil || job.Dir != e.lastDir || !maps.Equal(jobEnv, e.lastEnv) {
-		env := append(slices.Clone(e.env), envutil.ConvertEnv(jobEnv)...)
+		env := envutil.OverlayEnviron(e.env, jobEnv)
 		e.interp, err = interp.New(
 			interp.StdIO(e.stdin, e.stdout, e.stderr),
 			interp.Dir(job.Dir),

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -79,9 +79,9 @@ func TestDefaultExecutor_Execute_PerJobEnv(t *testing.T) {
 	}
 }
 
-// TestDefaultExecutor_Execute_JobEnvOverridesOSEnv a job's
-// environment must win over an inherited OS variable of the same name, so a
-// task's exportAs output overrides an external value.
+// TestDefaultExecutor_Execute_JobEnvOverridesOSEnv verifies that a job's environment
+// wins over an inherited OS variable of the same name, so a task's exportAs
+// output overrides an external value.
 func TestDefaultExecutor_Execute_JobEnvOverridesOSEnv(t *testing.T) {
 	t.Setenv("TASKCTL_ISSUE88", "external")
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -79,6 +79,30 @@ func TestDefaultExecutor_Execute_PerJobEnv(t *testing.T) {
 	}
 }
 
+// TestDefaultExecutor_Execute_JobEnvOverridesOSEnv a job's
+// environment must win over an inherited OS variable of the same name, so a
+// task's exportAs output overrides an external value.
+func TestDefaultExecutor_Execute_JobEnvOverridesOSEnv(t *testing.T) {
+	t.Setenv("TASKCTL_ISSUE88", "external")
+
+	e, err := NewDefaultExecutor(nil, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	job := NewJobFromCommand(`printf "%s" "$TASKCTL_ISSUE88"`)
+	job.Env = variables.FromMap(map[string]string{"TASKCTL_ISSUE88": "exported"})
+
+	out, err := e.Execute(context.Background(), job)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := strings.TrimSpace(string(out)); got != "exported" {
+		t.Errorf("job env must override OS env: got %q, want %q", got, "exported")
+	}
+}
+
 // TestDefaultExecutor_Execute_SharedShellState verifies that consecutive
 // commands sharing the same environment keep shell state: a function defined by
 // one command must be callable by the next (the executor reuses its

--- a/internal/envutil/envutil.go
+++ b/internal/envutil/envutil.go
@@ -22,6 +22,25 @@ func ConvertEnv(env map[string]string) []string {
 	return enva
 }
 
+// OverlayEnviron merges overlay onto a base environment (both in "key=value"
+// form / a map), letting overlay values win over base entries with the same
+// key. Base entries shadowed by overlay are dropped, then overlay is appended,
+// so the caller does not depend on a downstream dedup rule to decide precedence.
+func OverlayEnviron(base []string, overlay map[string]string) []string {
+	merged := make([]string, 0, len(base)+len(overlay))
+	for _, kv := range base {
+		k, _, ok := strings.Cut(kv, "=")
+		if ok {
+			if _, shadowed := overlay[k]; shadowed {
+				continue
+			}
+		}
+		merged = append(merged, kv)
+	}
+
+	return append(merged, ConvertEnv(overlay)...)
+}
+
 // ConvertToMapOfStrings converts map of interfaces to map of strings
 func ConvertToMapOfStrings(m map[string]any) map[string]string {
 	mdst := make(map[string]string)

--- a/internal/envutil/envutil.go
+++ b/internal/envutil/envutil.go
@@ -22,10 +22,10 @@ func ConvertEnv(env map[string]string) []string {
 	return enva
 }
 
-// OverlayEnviron merges overlay onto a base environment (both in "key=value"
-// form / a map), letting overlay values win over base entries with the same
-// key. Base entries shadowed by overlay are dropped, then overlay is appended,
-// so the caller does not depend on a downstream dedup rule to decide precedence.
+// OverlayEnviron merges overlay onto base (base in "key=value" form, overlay as a map).
+// For exact key matches, it drops shadowed base entries before appending overlay,
+// making precedence explicit. The result may still contain duplicates from base;
+// callers may still pass the list through a normalization/dedup step (e.g. Windows case-folding).
 func OverlayEnviron(base []string, overlay map[string]string) []string {
 	merged := make([]string, 0, len(base)+len(overlay))
 	for _, kv := range base {

--- a/internal/envutil/envutil_test.go
+++ b/internal/envutil/envutil_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -24,6 +25,30 @@ func TestConvertEnv(t *testing.T) {
 				t.Errorf("ConvertEnv() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestOverlayEnviron(t *testing.T) {
+	base := []string{"KEEP=base", "VAR_NAME=external", "MALFORMED"}
+	overlay := map[string]string{"VAR_NAME": "exported"}
+
+	got := OverlayEnviron(base, overlay)
+
+	want := map[string]string{"KEEP": "base", "MALFORMED": "", "VAR_NAME": "exported"}
+	seen := make(map[string]string, len(got))
+	for _, kv := range got {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			k = kv // malformed entry with no '=' is preserved verbatim
+		}
+		if _, dup := seen[k]; dup {
+			t.Errorf("OverlayEnviron() produced duplicate key %q: %v", k, got)
+		}
+		seen[k] = v
+	}
+
+	if !reflect.DeepEqual(seen, want) {
+		t.Errorf("OverlayEnviron() = %v, want %v", seen, want)
 	}
 }
 

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -117,6 +117,39 @@ func TestTaskRunner_PreExecutionFailureKeepsExitCode(t *testing.T) {
 	runner.Finish()
 }
 
+// TestTaskRunner_ExportAsOverridesExternalEnv reproduces issue #88: when a task
+// exports its output as an env var (exportAs) that already exists in the
+// external environment, a later task in the same pipeline must see the exported
+// value, not the inherited one. Pipeline stages share a single TaskRunner, so
+// running two tasks on one runner mirrors that flow.
+func TestTaskRunner_ExportAsOverridesExternalEnv(t *testing.T) {
+	t.Setenv("VAR_NAME", "external")
+
+	runner, err := NewTaskRunner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner.Stdout, runner.Stderr = io.Discard, io.Discard
+	defer runner.Finish()
+
+	producer := taskpkg.FromCommands(`printf "exported"`)
+	producer.Name = "producer"
+	producer.ExportAs = "VAR_NAME"
+	if err := runner.Run(producer); err != nil {
+		t.Fatal(err)
+	}
+
+	consumer := taskpkg.FromCommands(`printf "[%s]" "${VAR_NAME}"`)
+	consumer.Name = "consumer"
+	if err := runner.Run(consumer); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := consumer.Output(); !strings.Contains(got, "[exported]") {
+		t.Errorf("exportAs must override external env: got %q, want to contain %q", got, "[exported]")
+	}
+}
+
 func ExampleTaskRunner_Run() {
 	t := taskpkg.FromCommands("go fmt ./...", "go build ./..")
 	r, err := NewTaskRunner()


### PR DESCRIPTION
## Overview

Closes #88. When a task exports its output as an environment variable (`exportAs`) whose name already exists in the external environment, a later task in the same pipeline must see the *exported* value — not the inherited OS value. This PR makes that precedence explicit and guards it with regression tests.

## Root cause

The reported symptom (`exportAs` having no effect) came from the pre-rewrite v1.4.2 codebase. On current `main` the value already resolves correctly, but only *implicitly*: the executor appended the job environment after `os.Environ()` and leaned on `expand.ListEnviron`'s undocumented last-wins dedup to decide the winner. Correctness rested on a third-party library's internal ordering rule — fragile against any future refactor of how the env list is built.

## Decisions

- Resolve the override in taskctl's own code with a new `envutil.OverlayEnviron(base, overlay)` helper: OS entries shadowed by the job env are dropped, then job vars are appended. Precedence is now readable and unit-testable locally.
- Keep passing the result through `expand.ListEnviron`, so Windows case-folding behavior is preserved as a safety net.
- No new CLI flag, config key, or output field — behavior is unchanged for users; this is hardening plus regression coverage.

## Fix

- `executor/executor.go`: build the interpreter env via `envutil.OverlayEnviron(e.env, jobEnv)` instead of the raw append.
- `internal/envutil/envutil.go`: add the exported `OverlayEnviron` helper.
- Regression tests locking `exportAs`-overrides-external-env at three levels: `internal/envutil` (helper dedup/override), `executor` (`job.Env` beats a `t.Setenv` OS var), and `runner` (the exact #88 pipeline flow on a shared runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)