### PR TITLE
chore: modernize GoReleaser configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   goreleaser:
@@ -23,12 +24,21 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
-      - name: Docker login
-        uses: azure/docker-login@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
         with:
-          login-server: 'https://index.docker.io/v1/'
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
@@ -36,5 +46,4 @@ jobs:
           distribution: goreleaser
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{secrets.GORELEASER_GITHUB_TOKEN}}
-          GOPATH: ${{github.workspace}}
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,8 @@ builds:
   - binary: bin/taskctl
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     goos:
       - darwin
       - linux
@@ -18,14 +20,14 @@ builds:
       - "7"
     goarm64:
       - v8.0
-    gcflags:
-      - all=-trimpath={{.Env.GOPATH}}
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - LICENSE.md
       - README.md
@@ -54,28 +56,32 @@ release:
 checksum:
   name_template: checksums.txt
 
-brews:
+homebrew_casks:
   - commit_author:
       name: Yevhen Terentiev
       email: yevhen.terentiev@gmail.com
     homepage: https://github.com/taskctl/taskctl
-    extra_install: |
-        bash_completion.install "autocomplete/bash_completion.bash"
-        zsh_completion.install "autocomplete/zsh_completion.zsh"
+    description: Concurrent task runner and developer's routine tasks automation toolkit
+    binaries:
+      - bin/taskctl
+    completions:
+      bash: autocomplete/bash_completion.bash
+      zsh: autocomplete/zsh_completion.zsh
     repository:
       owner: taskctl
       name: homebrew-taskctl
 
-
-dockers:
-  - image_templates:
-      - "docker.io/taskctl/taskctl:latest"
-      - "ghcr.io/taskctl/taskctl:latest"
-      - "docker.io/taskctl/taskctl:{{ .Tag }}"
-      - "ghcr.io/taskctl/taskctl:{{ .Tag }}"
-    skip_push: auto
-    goos: linux
-    goarch: amd64
+dockers_v2:
+  - images:
+      - docker.io/taskctl/taskctl
+      - ghcr.io/taskctl/taskctl
+    tags:
+      - latest
+      - "{{ .Tag }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    disable: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
 
 scoops:
   - repository:
@@ -85,3 +91,4 @@ scoops:
       name: Yevhen Terentiev
       email: yevhen.terentiev@gmail.com
     homepage: https://github.com/taskctl/taskctl
+    description: Concurrent task runner and developer's routine tasks automation toolkit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine:latest
-COPY ./bin/taskctl /
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/bin/taskctl /
 ENTRYPOINT ["/taskctl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:latest
-ARG TARGETPLATFORM
-COPY $TARGETPLATFORM/bin/taskctl /
+ARG TARGETPLATFORM=.
+COPY ${TARGETPLATFORM}/bin/taskctl /
 ENTRYPOINT ["/taskctl"]

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ According to this plan, `lint` and `test` will run concurrently, and `build` wil
 #### macOS
 ```
 brew tap taskctl/taskctl
-brew install taskctl
+brew install --cask taskctl
 ```
 #### Linux
 ```


### PR DESCRIPTION
## Overview

- Update the release pipeline to current GoReleaser v2 configuration and remove all reported deprecations.
- Publish multi-architecture Docker images to Docker Hub and GHCR, and switch Homebrew distribution to a cask.

## Goal

- Keep releases compatible with current GoReleaser while preserving prerelease behavior and existing package formats.

## Decisions

- Use `dockers_v2` with Buildx for `linux/amd64` and `linux/arm64`; prerelease Docker publishing remains disabled.
- Use native cask completion declarations and document `brew install --cask taskctl`.
- The Homebrew tap should add `tap_migrations.json` and remove the old Formula after the first cask release so existing installs migrate cleanly.

## Verification

- `goreleaser check`
- `goreleaser release --snapshot --clean --skip=publish,docker`
- `go run . --output json --no-input prepare`