### PR TITLE
feat: rich persistent end-of-run summary, extended to single-task runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ tasks:
 | `-q, --quiet` | | quiet mode |
 | `--set <name=value>` | | set a global variable value (repeatable) |
 | `--dry-run` | | resolve and print commands without executing them |
-| `-s, --summary` | | show a run summary (default: `true`) |
+| `-s, --summary` | | show a run summary; on by default in human output modes, off with `--quiet` or in `raw` mode (unless opted in via config), never in `json`. An explicit flag wins over these defaults |
 | `--no-input` | `TASKCTL_NO_INPUT` | disable interactive prompts |
 | `-d, --debug` | `TASKCTL_DEBUG` | enable debug output |
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -227,7 +227,7 @@ func rootAction(c *cli.Context) (err error) {
 
 	targets := c.Args().Slice()
 	if len(targets) > 0 {
-		return runTargets(targetNames(targets, false), c, taskRunner)
+		return runTargets(targetNames(targets, false), taskRunner, summaryEnabled(c))
 	}
 
 	// No target: skip the selector when prompts are suppressed (--no-input/json)
@@ -255,11 +255,7 @@ func rootAction(c *cli.Context) (err error) {
 		return err
 	}
 
-	if selection.IsTask {
-		return runTask(cfg.Tasks[selection.Target], taskRunner)
-	}
-
-	return runPipeline(cfg.Pipelines[selection.Target], taskRunner, cfg.Summary || c.Bool("summary"))
+	return runTargets([]string{selection.Target}, taskRunner, summaryEnabled(c))
 }
 
 func buildTaskRunner(ctx context.Context, c *cli.Context) (*runner.TaskRunner, error) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -17,6 +17,7 @@ type appTest struct {
 	args        []string
 	errored     bool
 	output      []string
+	absent      []string
 	exactOutput string
 	stdin       io.ReadCloser
 }
@@ -68,6 +69,12 @@ func runAppTest(t *testing.T, app *cli.App, test appTest) {
 			if !strings.Contains(s, v) {
 				t.Errorf("\"%s\" not found in \"%s\"", v, s)
 			}
+		}
+	}
+
+	for _, v := range test.absent {
+		if strings.Contains(s, v) {
+			t.Errorf("\"%s\" unexpectedly found in \"%s\"", v, s)
 		}
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,13 +7,11 @@ import (
 	"maps"
 	"os"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/urfave/cli/v2"
 
 	"github.com/taskctl/taskctl/internal/output"
-	"github.com/taskctl/taskctl/internal/tui"
 	"github.com/taskctl/taskctl/runner"
 	"github.com/taskctl/taskctl/scheduler"
 	"github.com/taskctl/taskctl/task"
@@ -56,7 +54,7 @@ func newRunCommand() *cli.Command {
 				return errors.New("no target specified")
 			}
 
-			return runTargets(targetNames(c.Args().Slice(), true), c, taskRunner)
+			return runTargets(targetNames(c.Args().Slice(), true), taskRunner, summaryEnabled(c))
 		},
 		Subcommands: []*cli.Command{
 			{
@@ -85,7 +83,7 @@ func newRunCommand() *cli.Command {
 						}
 					}
 
-					emitRunFinished(nil, tasks, err)
+					finishRun(nil, tasks, summaryEnabled(c), err)
 					return err
 				},
 			},
@@ -99,7 +97,7 @@ func newRunCommand() *cli.Command {
 // graphs and directly-run tasks, and brackets the run with the run_started /
 // run_finished NDJSON events (no-ops outside json mode). It stops at the first
 // failing target and returns its error.
-func runTargets(targets []string, c *cli.Context, taskRunner *runner.TaskRunner) error {
+func runTargets(targets []string, taskRunner *runner.TaskRunner, summary bool) error {
 	emitRunStarted(targets)
 
 	var graphs []*scheduler.ExecutionGraph
@@ -107,7 +105,7 @@ func runTargets(targets []string, c *cli.Context, taskRunner *runner.TaskRunner)
 	var err error
 
 	for _, name := range targets {
-		g, t, terr := runTarget(name, c, taskRunner)
+		g, t, terr := runTarget(name, taskRunner)
 		if g != nil {
 			graphs = append(graphs, g)
 		}
@@ -120,17 +118,17 @@ func runTargets(targets []string, c *cli.Context, taskRunner *runner.TaskRunner)
 		}
 	}
 
-	emitRunFinished(graphs, tasks, err)
+	finishRun(graphs, tasks, summary, err)
 	return err
 }
 
 // runTarget runs the pipeline or task named by name and reports back
 // whichever of the two it ran, so callers can aggregate results for the
 // NDJSON run_finished event.
-func runTarget(name string, c *cli.Context, taskRunner *runner.TaskRunner) (g *scheduler.ExecutionGraph, t *task.Task, err error) {
+func runTarget(name string, taskRunner *runner.TaskRunner) (g *scheduler.ExecutionGraph, t *task.Task, err error) {
 	p := cfg.Pipelines[name]
 	if p != nil {
-		err = runPipeline(p, taskRunner, cfg.Summary || c.Bool("summary"))
+		err = runPipeline(p, taskRunner)
 		if err != nil {
 			return p, nil, fmt.Errorf("pipeline %q failed: %w", name, err)
 		}
@@ -149,28 +147,16 @@ func runTarget(name string, c *cli.Context, taskRunner *runner.TaskRunner) (g *s
 	return nil, t, nil
 }
 
-func runPipeline(g *scheduler.ExecutionGraph, taskRunner *runner.TaskRunner, summary bool) error {
+// runPipeline finishes the scheduler even when the run fails: Finish tears
+// down the live dashboard and runs context Down hooks, and the end-of-run
+// summary must print after that teardown.
+func runPipeline(g *scheduler.ExecutionGraph, taskRunner *runner.TaskRunner) error {
 	sd := scheduler.NewScheduler(taskRunner)
-	// go func() {
-	//	<-cancelCh
-	//	sd.Cancel()
-	// }()
 
 	err := sd.Schedule(g)
-	if err != nil {
-		return err
-	}
 	sd.Finish()
 
-	if cfg.Output != output.FormatJSON {
-		_, _ = fmt.Fprint(os.Stdout, "\r\n")
-
-		if summary {
-			printSummary(g)
-		}
-	}
-
-	return nil
+	return err
 }
 
 // targetNames extracts the list of target names from raw CLI args, stopping
@@ -286,15 +272,13 @@ func stageStatus(stage *scheduler.Stage) string {
 	}
 }
 
+// runTask finishes the runner even when the task fails, for the same
+// teardown-before-summary reason as runPipeline.
 func runTask(t *task.Task, taskRunner *runner.TaskRunner) error {
 	err := taskRunner.Run(t)
-	if err != nil {
-		return err
-	}
-
 	taskRunner.Finish()
 
-	return nil
+	return err
 }
 
 func taskArgs(c *cli.Context) []string {
@@ -313,34 +297,80 @@ func taskArgs(c *cli.Context) []string {
 	return runArgs
 }
 
-func printSummary(g *scheduler.ExecutionGraph) {
-	stages := slices.Collect(maps.Values(g.Nodes()))
-
-	slices.SortFunc(stages, func(a, b *scheduler.Stage) int {
-		return a.Start.Compare(b.Start)
-	})
-
-	tui.Println(os.Stdout, tui.StyleBold.Render("Summary:"))
-
-	var log string
-	for _, stage := range stages {
-		switch stage.ReadStatus() {
-		case scheduler.StatusDone:
-			tui.Println(os.Stdout, tui.StyleSuccess.Render(fmt.Sprintf("- Stage %s was completed in %s", stage.Name, stage.Duration())))
-		case scheduler.StatusSkipped:
-			tui.Println(os.Stdout, tui.StyleSuccess.Render(fmt.Sprintf("- Stage %s was skipped", stage.Name)))
-		case scheduler.StatusError:
-			log = strings.TrimSpace(stage.Task.ErrorMessage())
-			tui.Println(os.Stdout, tui.StyleError.Render(fmt.Sprintf("- Stage %s failed in %s", stage.Name, stage.Duration())))
-			if log != "" {
-				tui.Println(os.Stdout, tui.StyleError.Render("  > "+log))
-			}
-		case scheduler.StatusCanceled:
-			tui.Println(os.Stdout, tui.StyleFaint.Render(fmt.Sprintf("- Stage %s was cancelled", stage.Name)))
-		default:
-			tui.Println(os.Stdout, tui.StyleError.Render(fmt.Sprintf("- Unexpected status %d for stage %s", stage.Status, stage.Name)))
+// summaryEnabled reports whether the human end-of-run summary should print.
+// An explicitly passed --summary wins in both directions; the lineage walk is
+// required because the flag is declared on both the app root and the run
+// command, and c.Bool alone would resolve the nearest (possibly unset,
+// default-true) declaration, silently ignoring an explicit root-level value.
+// With no explicit flag: --quiet suppresses the summary, raw output defaults
+// it off (raw is meant for clean, pipeable output) unless config opts in, and
+// every other human mode defaults it on.
+func summaryEnabled(c *cli.Context) bool {
+	for _, ctx := range c.Lineage() {
+		if ctx.IsSet("summary") {
+			return ctx.Bool("summary")
 		}
 	}
 
-	tui.Printf(os.Stdout, "%s: %s\n", tui.StyleBold.Render("Total duration"), tui.StyleSuccess.Render(g.Duration().String()))
+	if cfg.Quiet {
+		return false
+	}
+
+	return cfg.Summary || cfg.Output != output.FormatRaw
+}
+
+// finishRun emits the run_finished NDJSON event (json mode) or, in a human
+// output mode with summary enabled, prints the persistent end-of-run summary.
+// It runs after the dashboard has torn down (via each caller's Finish), so the
+// summary stays on screen.
+func finishRun(graphs []*scheduler.ExecutionGraph, tasks []*task.Task, summary bool, err error) {
+	emitRunFinished(graphs, tasks, err)
+
+	if cfg.Output == output.FormatJSON || !summary {
+		return
+	}
+
+	var items []output.StageSummary
+	var total time.Duration
+	for _, g := range graphs {
+		items = append(items, summarizeGraph(g)...)
+		total += g.Duration()
+	}
+	for _, t := range tasks {
+		total += t.Duration()
+	}
+	items = append(items, output.SummarizeTasks(tasks)...)
+
+	if len(items) == 0 {
+		return
+	}
+
+	_, _ = fmt.Fprint(os.Stdout, "\r\n")
+	output.PrintRunSummary(os.Stdout, items, total)
+}
+
+func summarizeGraph(g *scheduler.ExecutionGraph) []output.StageSummary {
+	names := slices.Sorted(maps.Keys(g.Nodes()))
+	items := make([]output.StageSummary, 0, len(names))
+	for _, name := range names {
+		stage := g.Nodes()[name]
+
+		var s output.StageSummary
+		if stage.Task != nil {
+			s = output.SummarizeTask(stage.Task)
+		} else {
+			s.Start = stage.Start
+			s.Duration = stage.Duration()
+		}
+		s.Name = stage.Name
+		s.Status = stageStatus(stage)
+		// A condition-skipped task still leaves its stage Done — report the
+		// task-level "skipped" instead of success.
+		if s.Status == "done" && stage.Task != nil && stage.Task.Skipped {
+			s.Status = "skipped"
+		}
+
+		items = append(items, s)
+	}
+	return items
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -361,6 +361,9 @@ func summarizeGraph(g *scheduler.ExecutionGraph) []output.StageSummary {
 		} else {
 			s.Start = stage.Start
 			s.Duration = stage.Duration()
+			if stage.Pipeline != nil && stage.Pipeline.LastError() != nil {
+				s.ErrMessage = stage.Pipeline.LastError().Error()
+			}
 		}
 		s.Name = stage.Name
 		s.Status = stageStatus(stage)

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -9,9 +9,15 @@ func Test_runCommand(t *testing.T) {
 	tests := []appTest{
 		{args: []string{"", "--raw", "-c", "testdata/graph.yaml", "run", "graph:task2"}, errored: true},
 		{args: []string{"", "--raw", "-c", "testdata/graph.yaml", "run"}, errored: true},
+		// raw output defaults the summary off, so command output stays clean.
 		{args: []string{"", "--raw", "-c", "testdata/graph.yaml", "run", "graph:task1"}, exactOutput: "hello, world!\n"},
 		{args: []string{"", "--raw", "-c", "testdata/graph.yaml", "run", "task", "graph:task1"}, exactOutput: "hello, world!\n"},
-		{args: []string{"", "--raw", "-c", "testdata/graph.yaml", "run", "pipeline", "graph:pipeline1"}, output: []string{"graph:task3", "hello, world!\n"}},
+		// but an explicit --summary opts raw back in.
+		{args: []string{"", "--raw", "-c", "testdata/graph.yaml", "run", "--summary", "graph:task1"}, output: []string{"hello, world!", "succeeded", "total"}},
+		// a root-level --summary=false must not be shadowed by the run
+		// command's own (unset, default-true) flag declaration.
+		{args: []string{"", "--output=prefixed", "--summary=false", "-c", "testdata/graph.yaml", "run", "graph:task1"}, output: []string{"hello, world!"}, absent: []string{"succeeded", "total"}},
+		{args: []string{"", "--raw", "-c", "testdata/graph.yaml", "run", "--summary", "pipeline", "graph:pipeline1"}, output: []string{"graph:task3", "hello, world!\n"}},
 		{
 			args:   []string{"", "--output=prefixed", "-c", "testdata/graph.yaml", "run", "graph:pipeline1"},
 			output: []string{"graph:task1", "graph:task2", "graph:task3", "hello, world!"},
@@ -66,6 +72,28 @@ func Test_runCommand_json(t *testing.T) {
 	tasks, ok := last["tasks"].([]any)
 	if !ok || len(tasks) == 0 {
 		t.Errorf("expected run_finished.tasks to be a non-empty array, got %+v", last["tasks"])
+	}
+}
+
+// Test_runCommandSummary asserts the end-of-run summary is printed in a human
+// output mode: for a single-task run (the summary now extends to single tasks)
+// and for a pipeline (exercising summarizeGraph over stages, including the
+// nested sub-pipeline node). --output json is verified summary-free.
+func Test_runCommandSummary(t *testing.T) {
+	tests := []appTest{
+		{
+			args:   []string{"", "--output=prefixed", "-c", "testdata/graph.yaml", "graph:task1"},
+			output: []string{"hello, world!", "succeeded", "total"},
+		},
+		{
+			args:   []string{"", "--output=prefixed", "-c", "testdata/graph.yaml", "run", "graph:pipeline1"},
+			output: []string{"succeeded", "total", "graph:task1"},
+		},
+	}
+
+	for _, v := range tests {
+		app := makeTestApp()
+		runAppTest(t, app, v)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,6 +107,7 @@ func buildFromDefinition(def *configDefinition, lc *loaderContext) (cfg *Config,
 
 	cfg.Import = def.Import
 	cfg.Debug = def.Debug
+	cfg.Summary = def.Summary
 	cfg.Output = def.Output
 	cfg.Variables = cfg.Variables.Merge(variables.FromMap(def.Variables))
 

--- a/internal/output/summary.go
+++ b/internal/output/summary.go
@@ -1,0 +1,226 @@
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"time"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/taskctl/taskctl/internal/tui"
+	"github.com/taskctl/taskctl/task"
+)
+
+const logTailLines = 10
+
+// statusMarks drives both the counts header and the per-stage lines, in
+// display order. An unknown status (future typo or addition) falls back to
+// the last row rather than disappearing.
+var statusMarks = []struct {
+	status, sym, label string
+	style              *lipgloss.Style
+}{
+	{"done", "✔", "succeeded", &tui.StyleSuccess},
+	{"failed", "✗", "failed", &tui.StyleError},
+	{"skipped", "⊘", "skipped", &tui.StyleFaint},
+	{"canceled", "⊗", "canceled", &tui.StyleFaint},
+}
+
+// StageSummary is one row of the end-of-run summary — a task or pipeline stage
+// with its final status and captured-output stats.
+type StageSummary struct {
+	Name        string
+	Status      string
+	Start       time.Time
+	Duration    time.Duration
+	ExitCode    int16
+	OutputBytes int
+	ErrMessage  string
+	LogTail     []string
+}
+
+// SummarizeTask reads t's final state into a StageSummary without draining its
+// output buffers, so a later reader of t.Log still sees the full output.
+func SummarizeTask(t *task.Task) StageSummary {
+	s := StageSummary{
+		Name:        t.Name,
+		Status:      TaskStatus(t),
+		Start:       t.Start,
+		Duration:    t.Duration(),
+		ExitCode:    t.ExitCode,
+		OutputBytes: t.Log.Stdout.Len() + t.Log.Stderr.Len(),
+	}
+
+	// A task that "succeeded" without ever starting actually failed before
+	// execution (context, hook, or compile error) — those paths return an
+	// error without setting Errored or Start.
+	if s.Status == "done" && t.Start.IsZero() {
+		s.Status = "failed"
+	}
+
+	if t.Errored {
+		if t.Error != nil {
+			s.ErrMessage = strings.TrimSpace(t.Error.Error())
+		}
+		s.LogTail = lastLines(&t.Log.Stderr, logTailLines)
+		if len(s.LogTail) == 0 {
+			s.LogTail = lastLines(&t.Log.Stdout, logTailLines)
+		}
+	}
+
+	return s
+}
+
+// SummarizeTasks maps SummarizeTask over tasks, preserving their order.
+func SummarizeTasks(tasks []*task.Task) []StageSummary {
+	out := make([]StageSummary, 0, len(tasks))
+	for _, t := range tasks {
+		out = append(out, SummarizeTask(t))
+	}
+	return out
+}
+
+// PrintRunSummary writes the human end-of-run summary to w, ordering stages by
+// their start time regardless of the order items are passed in; stages that
+// never started (zero Start: skipped/canceled) sort after the ones that ran.
+func PrintRunSummary(w io.Writer, items []StageSummary, total time.Duration) {
+	items = slices.Clone(items)
+	slices.SortStableFunc(items, func(a, b StageSummary) int {
+		switch {
+		case a.Start.IsZero() && b.Start.IsZero():
+			return 0
+		case a.Start.IsZero():
+			return 1
+		case b.Start.IsZero():
+			return -1
+		}
+		return a.Start.Compare(b.Start)
+	})
+
+	tui.Println(w, summaryHeader(items, total))
+
+	nameWidth := 0
+	for _, it := range items {
+		nameWidth = max(nameWidth, lipgloss.Width(it.Name))
+	}
+
+	for _, it := range items {
+		tui.Println(w, summaryLine(it, nameWidth))
+		printFailureDetail(w, it)
+	}
+}
+
+// statusIndex resolves a status to its statusMarks row, falling back to the
+// last (canceled) row for unknown statuses so they are still counted and
+// rendered.
+func statusIndex(status string) int {
+	for i, m := range statusMarks {
+		if m.status == status {
+			return i
+		}
+	}
+	return len(statusMarks) - 1
+}
+
+func summaryHeader(items []StageSummary, total time.Duration) string {
+	counts := make([]int, len(statusMarks))
+	for _, it := range items {
+		counts[statusIndex(it.Status)]++
+	}
+
+	var parts []string
+	for i, m := range statusMarks {
+		if n := counts[i]; n > 0 {
+			parts = append(parts, m.style.Render(fmt.Sprintf("%s %d %s", m.sym, n, m.label)))
+		}
+	}
+	parts = append(parts, tui.StyleBold.Render(formatDuration(total)+" total"))
+
+	return strings.Join(parts, tui.StyleFaint.Render(" · "))
+}
+
+func summaryLine(it StageSummary, nameWidth int) string {
+	m := statusMarks[statusIndex(it.Status)]
+	pad := strings.Repeat(" ", max(0, nameWidth-lipgloss.Width(it.Name)))
+	line := m.style.Render(m.sym+" "+it.Name) + pad
+
+	switch it.Status {
+	case "skipped", "canceled":
+		return line + "  " + tui.StyleFaint.Render(it.Status)
+	}
+
+	line += "  " + formatDuration(it.Duration)
+	if it.Status == "failed" {
+		if it.ExitCode > 0 {
+			line += tui.StyleError.Render(fmt.Sprintf("  exit %d", it.ExitCode))
+		}
+		if it.OutputBytes > 0 {
+			line += tui.StyleFaint.Render(fmt.Sprintf("  (%s output)", humanizeBytes(it.OutputBytes)))
+		}
+	}
+	return line
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d >= time.Second:
+		return d.Round(10 * time.Millisecond).String()
+	case d >= time.Millisecond:
+		return d.Round(100 * time.Microsecond).String()
+	default:
+		return d.Round(time.Microsecond).String()
+	}
+}
+
+func printFailureDetail(w io.Writer, it StageSummary) {
+	if it.Status != "failed" {
+		return
+	}
+	if it.ErrMessage != "" {
+		tui.Println(w, tui.StyleFaint.Render("    "+it.ErrMessage))
+	}
+	for _, l := range it.LogTail {
+		tui.Println(w, tui.StyleFaint.Render("    "+l))
+	}
+}
+
+func lastLines(buf *bytes.Buffer, n int) []string {
+	trimmed := strings.TrimRight(buf.String(), "\r\n")
+	if trimmed == "" {
+		return nil
+	}
+
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	for i, l := range lines {
+		// Keep what the terminal would have displayed: drop the CR of CRLF
+		// endings, and for self-overwriting progress output keep only the
+		// segment after the last carriage return — raw CRs would re-home the
+		// cursor and overwrite the indented tail block.
+		l = strings.TrimRight(l, "\r")
+		if j := strings.LastIndexByte(l, '\r'); j >= 0 {
+			l = l[j+1:]
+		}
+		lines[i] = l
+	}
+	return lines
+}
+
+func humanizeBytes(n int) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+
+	div, exp := int64(unit), 0
+	for i := int64(n) / unit; i >= unit; i /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGT"[exp])
+}

--- a/internal/output/summary.go
+++ b/internal/output/summary.go
@@ -187,16 +187,29 @@ func printFailureDetail(w io.Writer, it StageSummary) {
 	}
 }
 
+// lastLines extracts the final n lines without copying the whole buffer: it
+// scans backwards for line boundaries and converts only the bounded tail,
+// keeping the cost independent of how large the captured log is.
 func lastLines(buf *bytes.Buffer, n int) []string {
-	trimmed := strings.TrimRight(buf.String(), "\r\n")
-	if trimmed == "" {
+	b := bytes.TrimRight(buf.Bytes(), "\r\n")
+	if len(b) == 0 {
 		return nil
 	}
 
-	lines := strings.Split(trimmed, "\n")
-	if len(lines) > n {
-		lines = lines[len(lines)-n:]
+	start := len(b)
+	for range n {
+		nl := bytes.LastIndexByte(b[:start], '\n')
+		if nl < 0 {
+			start = 0
+			break
+		}
+		start = nl
 	}
+	if start > 0 {
+		start++ // step past the newline preceding the tail
+	}
+
+	lines := strings.Split(string(b[start:]), "\n")
 	for i, l := range lines {
 		// Keep what the terminal would have displayed: drop the CR of CRLF
 		// endings, and for self-overwriting progress output keep only the

--- a/internal/output/summary_test.go
+++ b/internal/output/summary_test.go
@@ -1,0 +1,189 @@
+package output
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/taskctl/taskctl/task"
+)
+
+func failedTask(name, stderr string, exit int16) *task.Task {
+	t := &task.Task{Name: name, Errored: true, Error: errors.New("exit status 2"), ExitCode: exit}
+	t.Start = time.Unix(0, 0)
+	t.End = time.Unix(2, 0)
+	t.Log.Stderr.WriteString(stderr)
+	return t
+}
+
+func TestSummarizeTask(t *testing.T) {
+	done := &task.Task{Name: "build"}
+	done.Start = time.Unix(0, 0)
+	done.End = time.Unix(1, 0)
+	done.Log.Stdout.WriteString("compiled\n")
+
+	skipped := &task.Task{Name: "deploy", Skipped: true}
+
+	failed := failedTask("test", "line1\nboom: assertion failed\n", 2)
+
+	tests := []struct {
+		name       string
+		task       *task.Task
+		wantStatus string
+		wantExit   int16
+		wantBytes  int
+		wantErrMsg string
+		wantTail   []string
+	}{
+		{"done", done, "done", 0, len("compiled\n"), "", nil},
+		{"skipped", skipped, "skipped", 0, 0, "", nil},
+		{"failed", failed, "failed", 2, len("line1\nboom: assertion failed\n"), "exit status 2", []string{"line1", "boom: assertion failed"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SummarizeTask(tt.task)
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", got.Status, tt.wantStatus)
+			}
+			if got.ExitCode != tt.wantExit {
+				t.Errorf("ExitCode = %d, want %d", got.ExitCode, tt.wantExit)
+			}
+			if got.OutputBytes != tt.wantBytes {
+				t.Errorf("OutputBytes = %d, want %d", got.OutputBytes, tt.wantBytes)
+			}
+			if got.ErrMessage != tt.wantErrMsg {
+				t.Errorf("ErrMessage = %q, want %q", got.ErrMessage, tt.wantErrMsg)
+			}
+			if strings.Join(got.LogTail, "|") != strings.Join(tt.wantTail, "|") {
+				t.Errorf("LogTail = %v, want %v", got.LogTail, tt.wantTail)
+			}
+		})
+	}
+}
+
+// A task whose flags say "done" but that never started actually failed before
+// execution (context/hook/compile error paths return an error without setting
+// Errored or Start) — the summary must not report it as succeeded.
+func TestSummarizeTaskNeverStartedIsFailed(t *testing.T) {
+	got := SummarizeTask(&task.Task{Name: "x"})
+	if got.Status != "failed" {
+		t.Errorf("Status = %q, want %q", got.Status, "failed")
+	}
+}
+
+func TestSummarizeTaskFailedFallsBackToStdout(t *testing.T) {
+	t2 := &task.Task{Name: "x", Errored: true, Error: errors.New("boom")}
+	t2.Log.Stdout.WriteString("only-stdout\n")
+
+	got := SummarizeTask(t2)
+	if want := []string{"only-stdout"}; strings.Join(got.LogTail, "|") != strings.Join(want, "|") {
+		t.Errorf("LogTail = %v, want %v", got.LogTail, want)
+	}
+}
+
+func TestLastLines(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		n     int
+		want  []string
+	}{
+		{"empty", "", 3, nil},
+		{"only newlines", "\n\n", 3, nil},
+		{"fewer than n", "a\nb", 5, []string{"a", "b"}},
+		{"trailing newline", "a\nb\n", 5, []string{"a", "b"}},
+		{"more than n", "a\nb\nc\nd", 2, []string{"c", "d"}},
+		{"single no newline", "x", 10, []string{"x"}},
+		{"crlf endings", "a\r\nb\r\n", 5, []string{"a", "b"}},
+		{"progress overwrites", "10%\r50%\r100%\nok\n", 5, []string{"100%", "ok"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := bytes.NewBufferString(tt.input)
+			got := lastLines(buf, tt.n)
+			if strings.Join(got, "|") != strings.Join(tt.want, "|") {
+				t.Errorf("lastLines(%q, %d) = %v, want %v", tt.input, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHumanizeBytes(t *testing.T) {
+	tests := []struct {
+		in   int
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+	}
+
+	for _, tt := range tests {
+		if got := humanizeBytes(tt.in); got != tt.want {
+			t.Errorf("humanizeBytes(%d) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestPrintRunSummary(t *testing.T) {
+	items := []StageSummary{
+		{Name: "build", Status: "done", Start: time.Unix(1, 0), Duration: time.Second},
+		{Name: "test", Status: "failed", Start: time.Unix(2, 0), Duration: 3 * time.Second, ExitCode: 2, OutputBytes: 2048, ErrMessage: "exit status 2", LogTail: []string{"assertion failed"}},
+		{Name: "deploy", Status: "skipped", Start: time.Unix(3, 0)},
+	}
+
+	var buf bytes.Buffer
+	PrintRunSummary(&buf, items, 4*time.Second)
+	out := buf.String()
+
+	for _, want := range []string{
+		"1 succeeded", "1 failed", "1 skipped", "4s total",
+		"build", "test", "deploy",
+		"exit 2", "2.0 KB output", "assertion failed", "skipped",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintRunSummarySortsByStart(t *testing.T) {
+	items := []StageSummary{
+		{Name: "never-ran", Status: "skipped"}, // zero Start sorts last, not first
+		{Name: "second", Status: "done", Start: time.Unix(2, 0), Duration: time.Second},
+		{Name: "first", Status: "done", Start: time.Unix(1, 0), Duration: time.Second},
+	}
+
+	var buf bytes.Buffer
+	PrintRunSummary(&buf, items, 2*time.Second)
+	out := buf.String()
+
+	if strings.Index(out, "first") > strings.Index(out, "second") {
+		t.Errorf("expected 'first' before 'second' by start time\n%s", out)
+	}
+	if strings.Index(out, "never-ran") < strings.Index(out, "second") {
+		t.Errorf("expected zero-Start 'never-ran' after started stages\n%s", out)
+	}
+}
+
+// A failed row without a real exit code (nested sub-pipeline stages,
+// pre-execution failures) must not claim "exit 0".
+func TestPrintRunSummaryNoFabricatedExitCode(t *testing.T) {
+	items := []StageSummary{
+		{Name: "sub", Status: "failed", Start: time.Unix(1, 0), Duration: time.Second},
+	}
+
+	var buf bytes.Buffer
+	PrintRunSummary(&buf, items, time.Second)
+
+	if strings.Contains(buf.String(), "exit") {
+		t.Errorf("expected no exit code for zero-exit failed row\n%s", buf.String())
+	}
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -94,9 +94,19 @@ func (r *TaskRunner) SetVariables(vars variables.Container) *TaskRunner {
 }
 
 // Run run provided task.
-// TaskRunner first compiles task into linked list of Jobs, then passes those jobs to Executor
-func (r *TaskRunner) Run(t *task.Task) error {
+// TaskRunner first compiles task into linked list of Jobs, then passes those jobs to Executor.
+// Any failure — including errors before execution starts (context resolution,
+// hooks, compilation) — is recorded on the task via Errored/Error.
+func (r *TaskRunner) Run(t *task.Task) (err error) {
 	defer func() {
+		// Pre-execution failures return an error without reaching execute(),
+		// which is what normally marks the task; record them here so task
+		// status and error reporting reflect the failure.
+		if err != nil && !t.Errored {
+			t.Errored = true
+			t.Error = err
+		}
+
 		r.cancelMutex.RLock()
 		if r.canceling {
 			close(r.doneCh)

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -114,6 +114,10 @@ func TestTaskRunner_PreExecutionFailureKeepsExitCode(t *testing.T) {
 		t.Errorf("task that never executed must not report a success exit code, got %d", tsk.ExitCode)
 	}
 
+	if !tsk.Errored || tsk.Error == nil {
+		t.Errorf("pre-execution failure must be recorded on the task, got Errored=%v Error=%v", tsk.Errored, tsk.Error)
+	}
+
 	runner.Finish()
 }
 


### PR DESCRIPTION
## Overview

Every run now ends with a rich, persistent summary: a counts header (`✔ 3 succeeded · ✗ 1 failed · ⊘ 1 skipped · 4.2s total`), one aligned line per stage with status glyph and duration (plus exit code and captured-output size on failure), and the error message with the last 10 lines of stderr for each failed stage. Single-task runs — which previously printed no summary at all — get the same treatment as pipelines.

## Goal

The live dashboard shows only spinners and "finished" lines and collapses on exit, so the summary is the primary artifact a user is left with once the program exits. The old one was thin (stage name + duration), pipeline-only, and gave no failure detail — precisely when it mattered most.

## Decisions

- **One summary per run**, printed by a single finalizer (`finishRun`) shared with the NDJSON `run_finished` event, covering all targets of a multi-target run.
- **Placement**: the reusable model/renderer (`StageSummary`, `SummarizeTask(s)`, `PrintRunSummary`) live in `internal/output`; the scheduler-coupled glue (`summarizeGraph`) stays in `cmd` — `output` must not import `scheduler` (`scheduler → runner → output` would close a cycle).
- **When it prints**: an explicit `--summary`/`-s` wins in both directions, resolved across the flag's root and `run`-level declarations (a root-level `--summary=false` used to be silently shadowed by the run command's default-true flag). With no explicit flag: `--quiet` suppresses it, `raw` defaults it off to keep pipeable output clean (config `summary: true` opts back in — that key was previously a silent no-op, never copied from the parsed config), other human modes default on, `json` never prints it.
- **Teardown ordering**: scheduler/runner `Finish()` now also runs on failure paths, so the summary always prints after the dashboard has torn down (and context `down` hooks fire) — failures are exactly when the summary matters.
- Review hardening: condition-skipped stages report `skipped` (not `done`), never-started stages sort after the ones that ran, pre-execution failures (bad template, failed `up` hook) report `failed` instead of `✔ succeeded`, failed rows without a real exit code no longer claim `exit 0`, and CRLF/progress-bar output can't corrupt the failure tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)