### PR TITLE
feat: configurable "default" context for tasks without one (#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Predefined variables are:
 - `.ArgsList` - array of provided arguments
 - `.Output` - previous command's output
 - `.Task` - the running task's static metadata: `.Task.Name`, `.Task.Description`, `.Task.Dir`, `.Task.Context`, `.Task.Condition`, `.Task.Timeout`, `.Task.AllowFailure`, `.Task.Interactive`, `.Task.ExportAs`
-- `.Context` - the resolved execution context: `.Context.Name`, `.Context.Dir`, `.Context.Executable` (with `.Context.Executable.Bin` and `.Context.Executable.Args`; `.Context.Executable` is nil for the default context)
+- `.Context` - the resolved execution context: `.Context.Name`, `.Context.Dir`, `.Context.Executable` (with `.Context.Executable.Bin` and `.Context.Executable.Args`; `.Context.Executable` is nil when the context sets no executable)
 - `.Stage` - when the task runs inside a pipeline stage: `.Stage.Name`, `.Stage.Condition`, `.Stage.Dir`, `.Stage.AllowFailure`, `.Stage.DependsOn`
 - `.Tasks.<Name>` - results of an already-completed task, visible across the whole run: `.Tasks.<Name>.Stdout`, `.Tasks.<Name>.Stderr`, `.Tasks.<Name>.ExitCode`. `<Name>` is title-cased, so task `producer` is `.Tasks.Producer.Stdout`. A name containing a dash can't use field syntax (`{{ .Tasks.Build-Host.Stdout }}` fails to parse) - use `{{ (index .Tasks "Build-Host").Stdout }}` instead
 
@@ -407,6 +407,8 @@ A context definition takes the following parameters:
 - `env_file` - file with env variables in `k=v` format to read variables from
 - `variables` - context's variables
 - `up`, `down`, `before`, `after` - lifecycle hooks (see below)
+
+A task that declares no `context:` runs in the context named `default`. Define one to share environment variables, variables, a working directory, executable or lifecycle hooks across every such task — this is how you give all tasks a common `env`. A task's own `env`/`variables` override the default context's (precedence: `default context < task`). Tasks that opt into another context use that one instead; if no `default` context is defined, context-less tasks run in an empty implicit context.
 
 A context has lifecycle hooks: `up` and `down` run once per taskctl run - `up` before the context's first usage, `down` during cleanup when the run finishes. `before` and `after` run every time around each task that uses the context.
 ```yaml

--- a/docs/example.yaml
+++ b/docs/example.yaml
@@ -35,7 +35,7 @@ tasks:
       sleep: 10
 
   task3:
-    context: docker-compose-context-name
+    context: docker-compose-context
     command:
       - echo "Hello from container created by docker-compose"
       - echo ${TASK1_STORED_OUTPUT}

--- a/docs/example.yaml
+++ b/docs/example.yaml
@@ -1,6 +1,6 @@
 tasks:
   task1:
-    context: local # optional. "local" is context by default
+    context: default # optional; a task with no context uses the "default" context
     description: "Optional description for task1"
     command:
       - echo ${ARGS} # ARGS is populated by arguments passed to task. eg. taskctl run task task1 -- arg1 arg2
@@ -35,7 +35,7 @@ tasks:
       sleep: 10
 
   task3:
-    context: docker-compose-context-name # local is default context
+    context: docker-compose-context-name
     command:
       - echo "Hello from container created by docker-compose"
       - echo ${TASK1_STORED_OUTPUT}
@@ -113,7 +113,7 @@ watchers:
     task: test-watch-task-2
 
 contexts:
-  local: # will be created automatically if not set
+  default: # used by any task that sets no context; an empty one is used if not defined
     executable:
       bin: /bin/zsh
       args:

--- a/docs/example.yaml
+++ b/docs/example.yaml
@@ -1,6 +1,6 @@
 tasks:
   task1:
-    context: default # optional; a task with no context uses the "default" context
+    # context: default # optional; omit to use the "default" context
     description: "Optional description for task1"
     command:
       - echo ${TASKCTL__ARGS} # TASKCTL__ARGS is populated by arguments passed to task. eg. taskctl run task task1 -- arg1 arg2

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -26,7 +26,7 @@ import (
 
 // defaultContextName is the context a task falls back to when it declares no
 // context: if the config defines a context by this name it is used (so its env,
-// variables and hooks apply to every such task), otherwise an empty context is.
+// variables and hooks apply to every such task), otherwise an empty context is used.
 const defaultContextName = "default"
 
 // Runner describes tasks runner interface

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -24,6 +24,11 @@ import (
 	"github.com/taskctl/taskctl/task"
 )
 
+// defaultContextName is the context a task falls back to when it declares no
+// context: if the config defines a context by this name it is used (so its env,
+// variables and hooks apply to every such task), otherwise an empty context is.
+const defaultContextName = "default"
+
 // Runner describes tasks runner interface
 type Runner interface {
 	Run(t *task.Task) error
@@ -314,16 +319,19 @@ func (r *TaskRunner) after(ctx context.Context, t *task.Task, env, vars variable
 }
 
 func (r *TaskRunner) contextForTask(ctx context.Context, t *task.Task) (c *ExecutionContext, err error) {
-	if t.Context == "" {
-		c = defaultContext()
-	} else {
-		var ok bool
-		c, ok = r.contexts[t.Context]
-		if !ok {
-			return nil, fmt.Errorf("no such context %s", t.Context)
-		}
+	name := t.Context
+	if name == "" {
+		name = defaultContextName
+	}
 
-		r.cleanupList.Store(t.Context, c)
+	c, ok := r.contexts[name]
+	switch {
+	case ok:
+		r.cleanupList.Store(name, c)
+	case t.Context != "":
+		return nil, fmt.Errorf("no such context %s", t.Context)
+	default:
+		c = defaultContext()
 	}
 
 	err = c.Up(ctx)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -324,7 +324,8 @@ func (r *TaskRunner) contextForTask(ctx context.Context, t *task.Task) (c *Execu
 		name = defaultContextName
 	}
 
-	c, ok := r.contexts[name]
+	var ok bool
+	c, ok = r.contexts[name]
 	switch {
 	case ok:
 		r.cleanupList.Store(name, c)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -329,7 +329,7 @@ func (r *TaskRunner) contextForTask(ctx context.Context, t *task.Task) (c *Execu
 	case ok:
 		r.cleanupList.Store(name, c)
 	case t.Context != "":
-		return nil, fmt.Errorf("no such context %s", t.Context)
+		return nil, fmt.Errorf("no such context %q", t.Context)
 	default:
 		c = defaultContext()
 	}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -199,6 +199,71 @@ func TestTaskRunner_ContextVariables(t *testing.T) {
 	runner.Finish()
 }
 
+func TestTaskRunner_DefaultContext(t *testing.T) {
+	defaultCtx := NewExecutionContext(nil, "", variables.FromMap(map[string]string{
+		"GLOBAL_ENV": "from-default",
+		"SHARED_ENV": "default-wins",
+	}), nil, nil, nil, nil)
+	otherCtx := NewExecutionContext(nil, "", variables.NewVariables(), nil, nil, nil, nil)
+
+	runner, err := NewTaskRunner(WithContexts(map[string]*ExecutionContext{
+		defaultContextName: defaultCtx,
+		"other":            otherCtx,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner.Stdout, runner.Stderr = io.Discard, io.Discard
+	defer runner.Finish()
+
+	inherit := taskpkg.FromCommands(`printf "[%s]" "$GLOBAL_ENV"`)
+	inherit.Name = "inherit"
+
+	override := taskpkg.FromCommands(`printf "[%s]" "$SHARED_ENV"`)
+	override.Name = "override"
+	override.Env = variables.FromMap(map[string]string{"SHARED_ENV": "task-wins"})
+
+	explicit := taskpkg.FromCommands(`printf "[%s]" "${GLOBAL_ENV:-unset}"`)
+	explicit.Name = "explicit"
+	explicit.Context = "other"
+
+	cases := []struct {
+		t    *taskpkg.Task
+		want string
+	}{
+		{t: inherit, want: "[from-default]"}, // no context -> inherits the default context env
+		{t: override, want: "[task-wins]"},   // task env overrides the default context env
+		{t: explicit, want: "[unset]"},       // an explicit context does not see the default context env
+	}
+
+	for _, tc := range cases {
+		if err := runner.Run(tc.t); err != nil {
+			t.Fatalf("%s: %v", tc.t.Name, err)
+		}
+		if !strings.Contains(tc.t.Stdout(), tc.want) {
+			t.Errorf("%s: output %q does not contain %q", tc.t.Name, tc.t.Stdout(), tc.want)
+		}
+	}
+}
+
+func TestTaskRunner_NoDefaultContext(t *testing.T) {
+	runner, err := NewTaskRunner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner.Stdout, runner.Stderr = io.Discard, io.Discard
+	defer runner.Finish()
+
+	tsk := taskpkg.FromCommands(`printf "ok"`)
+	tsk.Name = "plain"
+	if err := runner.Run(tsk); err != nil {
+		t.Fatalf("context-less task must run without a default context: %v", err)
+	}
+	if got := tsk.Stdout(); !strings.Contains(got, "ok") {
+		t.Errorf("context-less task output %q does not contain %q", got, "ok")
+	}
+}
+
 // TestTaskRunner_ExportAsOverridesExternalEnv reproduces issue #88: when a task
 // exports its output as an env var (exportAs) that already exists in the
 // external environment, a later task in the same pipeline must see the exported


### PR DESCRIPTION
## Overview

- Adds a supported way to give **all tasks a common `env`** (and variables, working dir, executable, and lifecycle hooks): a context named `default` now backs any task that declares no `context:`. Resolves discussion #85.

## Goal

- Discussion [#85](https://github.com/taskctl/taskctl/discussions/85) asked for *"a common `env:` for all tasks."* Previously `env` could only be set per-task, per-context, or per-stage — there was no shared baseline. The empty-context case built a throwaway empty context and never consulted the configured `contexts:` map.

## Decisions

- Modeled the shared baseline through the existing **context** mechanism instead of a new top-level `env:` key. It's the smaller change (only `contextForTask`), needs no new config schema, and reuses the whole context feature set — `env`, `variables`, `dir`, `executable`, and `up`/`down`/`before`/`after` hooks all apply to default-context tasks for free.
- Precedence is `default context < task`: a task's own `env`/`variables` override the default context's for the same key (falls out of the existing merge order).
- Contexts stay selectable — a task with an explicit `context:` uses that one and does **not** inherit `default`.
- Backward compatible: when no `default` context is defined, context-less tasks still run in an empty implicit context.

## Usage

```yaml
contexts:
  default:
    env:
      GREETING: hello-global
tasks:
  show:      { command: 'echo "$GREETING"' }                              # hello-global
  override:  { env: { GREETING: hello-task }, command: 'echo "$GREETING"' } # hello-task
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)