### PR TITLE
feat: namespace runtime-injected env vars with TASKCTL__ prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ tasks:
 ```
 
 ### Pass CLI arguments to task
-Any command line arguments succeeding `--` are passed to each task via the `.Args` and `.ArgsList` variables or the `ARGS` environment variable.
+Any command line arguments succeeding `--` are passed to each task via the `.Args` and `.ArgsList` variables or the `TASKCTL__ARGS` environment variable.
 
 Given this definition:
 ```yaml

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -21,7 +21,7 @@ func newRunCommand(cfg *config.Config) *cobra.Command {
 	runCmd := &cobra.Command{
 		Use:     "run TARGET [TARGET...] [-- task-args]",
 		Short:   "run one or more pipelines or tasks",
-		Long:    "Runs one or more named pipelines or tasks in order, stopping at the first failure. Arguments after \"--\" are passed to each task via the `.Args`/`.ArgsList` template variables or the `ARGS` environment variable.",
+		Long:    "Runs one or more named pipelines or tasks in order, stopping at the first failure. Arguments after \"--\" are passed to each task via the `.Args`/`.ArgsList` template variables or the `TASKCTL__ARGS` environment variable.",
 		GroupID: groupRun,
 		Example: "  taskctl run pipeline1\n" +
 			"  taskctl run task1 task2\n" +

--- a/docs/cli/taskctl_run.md
+++ b/docs/cli/taskctl_run.md
@@ -4,7 +4,7 @@ run one or more pipelines or tasks
 
 ### Synopsis
 
-Runs one or more named pipelines or tasks in order, stopping at the first failure. Arguments after "--" are passed to each task via the `.Args`/`.ArgsList` template variables or the `ARGS` environment variable.
+Runs one or more named pipelines or tasks in order, stopping at the first failure. Arguments after "--" are passed to each task via the `.Args`/`.ArgsList` template variables or the `TASKCTL__ARGS` environment variable.
 
 ```
 taskctl run TARGET [TARGET...] [-- task-args] [flags]

--- a/docs/example.yaml
+++ b/docs/example.yaml
@@ -3,7 +3,7 @@ tasks:
     context: local # optional. "local" is context by default
     description: "Optional description for task1"
     command:
-      - echo ${ARGS} # ARGS is populated by arguments passed to task. eg. taskctl run task task1 -- arg1 arg2
+      - echo ${TASKCTL__ARGS} # TASKCTL__ARGS is populated by arguments passed to task. eg. taskctl run task task1 -- arg1 arg2
       - echo {{ .Args | default 'some value' }} # .Args is populated by arguments passed to task. eg. taskctl run task task1 -- arg1 arg2
       - echo {{ index .ArgsList 0 }} # .ArgsList is populated by list of arguments passed to task. eg. taskctl run task task1 -- arg1 arg2
       - echo "My name is task1"

--- a/internal/config/testdata/tasks.yaml
+++ b/internal/config/testdata/tasks.yaml
@@ -25,7 +25,7 @@ tasks:
     dir: "{{ .Root }}/bin"
     condition: /usr/bin/true
     command:
-      - echo ${ARGS}
+      - echo ${TASKCTL__ARGS}
       - echo "Args - {{ .Args }}"
       - sleep {{ .sleep }}
     env:

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -24,6 +24,12 @@ import (
 	"github.com/taskctl/taskctl/task"
 )
 
+// injectedEnvPrefix namespaces the environment variables taskctl injects into a
+// task's process, keeping them clear of the user's own env. The double
+// underscore distinguishes these injected values from the single-underscore
+// TASKCTL_ config vars (e.g. TASKCTL_OUTPUT_FORMAT) that taskctl reads.
+const injectedEnvPrefix = "TASKCTL__"
+
 // Runner describes tasks runner interface
 type Runner interface {
 	Run(t *task.Task) error
@@ -109,7 +115,7 @@ func NewTaskRunner(opts ...Opts) (*TaskRunner, error) {
 		o(r)
 	}
 
-	r.env = variables.FromMap(map[string]string{"ARGS": r.variables.Get("Args").(string)})
+	r.env = variables.FromMap(map[string]string{injectedEnvPrefix + "ARGS": r.variables.Get("Args").(string)})
 
 	return r, nil
 }
@@ -185,7 +191,7 @@ func (r *TaskRunner) Run(t *task.Task) (err error) {
 	vars.Set("Tasks", r.results.Snapshot())
 
 	env := r.env.Merge(execContext.Env)
-	env = env.With("TASK_NAME", t.Name)
+	env = env.With(injectedEnvPrefix+"TASK_NAME", t.Name)
 	env = env.Merge(t.Env)
 
 	meets, err := r.checkTaskCondition(t, env, vars)

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -257,6 +257,44 @@ func TestTaskRunner_NoEnvExportWithoutExportAs(t *testing.T) {
 	}
 }
 
+func TestTaskRunner_InjectsPrefixedTaskName(t *testing.T) {
+	runner, err := NewTaskRunner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner.Stdout, runner.Stderr = io.Discard, io.Discard
+	defer runner.Finish()
+
+	tsk := taskpkg.FromCommands(`printf "[%s]" "${TASKCTL__TASK_NAME}"`)
+	tsk.Name = "build"
+	if err := runner.Run(tsk); err != nil {
+		t.Fatal(err)
+	}
+	if got := tsk.Stdout(); !strings.Contains(got, "[build]") {
+		t.Errorf("TASKCTL__TASK_NAME must hold the task name: got %q", got)
+	}
+}
+
+func TestTaskRunner_InjectsPrefixedArgs(t *testing.T) {
+	runner, err := NewTaskRunner(
+		WithVariables(variables.FromMap(map[string]string{"Args": "hello world"})),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner.Stdout, runner.Stderr = io.Discard, io.Discard
+	defer runner.Finish()
+
+	tsk := taskpkg.FromCommands(`printf "[%s]" "${TASKCTL__ARGS}"`)
+	tsk.Name = "echo-args"
+	if err := runner.Run(tsk); err != nil {
+		t.Fatal(err)
+	}
+	if got := tsk.Stdout(); !strings.Contains(got, "[hello world]") {
+		t.Errorf("TASKCTL__ARGS must hold the passthrough args: got %q", got)
+	}
+}
+
 func TestTaskRunner_TasksStdoutVariable(t *testing.T) {
 	runner, err := NewTaskRunner()
 	if err != nil {


### PR DESCRIPTION
## Overview

taskctl injects environment variables into every task's process. Their names now carry a `TASKCTL__` prefix so they can't silently collide with a user's own environment:

- `ARGS` → `TASKCTL__ARGS`
- `TASK_NAME` → `TASKCTL__TASK_NAME`

> [!WARNING]
> **Breaking change.** Task commands referencing `${ARGS}` or `${TASK_NAME}` must now use `${TASKCTL__ARGS}` / `${TASKCTL__TASK_NAME}`. The `.Args`/`.ArgsList` template variables are unchanged.

## Goal

The injected vars previously lived in the unprefixed global namespace, where a task's own `env` or an inherited OS variable named `ARGS` or `TASK_NAME` would clash with taskctl's values. Namespacing them removes that footgun and makes it obvious which env vars come from taskctl.

## Decisions

- **Double underscore (`TASKCTL__`)** deliberately distinguishes the values taskctl *injects into tasks* from the single-underscore `TASKCTL_` config vars it *reads* (e.g. `TASKCTL_OUTPUT_FORMAT`).
- **`exportAs` is left unprefixed** — it's the user's explicitly chosen name; prefixing it would defeat its purpose.
- **Scope is env-var KEY names only.** Template variables (`.Args`, `.ArgsList`, `.Task.*`, `.Tasks.<Name>.Stdout`) are a separate mechanism and untouched.
- The prefix lives in a single `injectedEnvPrefix` const in `runner/runner.go`, applied at both injection sites.

Docs (`README.md`, `docs/example.yaml`, generated `docs/cli/`) and the config test fixture were updated to match; two regression tests assert the prefixed vars reach the task process.