### PR TITLE
feat: typed execution contexts (docker, kubernetes, ssh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ contexts:
   cluster:
     type: kubernetes
     kubernetes:
-      pod: web-0                  # required
+      pod: web-0                  # required; also accepts a controller ref, e.g. deployment/web
       namespace: stage
       container: app              # optional `-c` container within the pod
       kube_context: my-ctx        # optional `--context`
@@ -470,6 +470,8 @@ contexts:
 ```
 
 Docker **run mode** (`image:`) starts a fresh `--rm` container for every command, so state does not persist between commands — an `up:` install step won't be visible to later commands. For stateful setup use **exec mode** (`container:`) against a container you start yourself (e.g. from a `local`/escape-hatch `up:` hook or out of band), or use kubernetes/ssh.
+
+The `kubernetes` `pod:` value is passed through to `kubectl exec` verbatim, so it accepts any target `kubectl exec` understands — a bare pod name (`web-0`) or a controller reference (`deployment/web`, `statefulset/db`, `daemonset/agent`, `job/migrate`, `svc/api`). For a controller, kubectl selects one of its pods (the first, not all replicas).
 
 Validation: `docker` requires exactly one of `image`/`container`; `kubernetes` requires `pod`; `ssh` requires `host`. A typed context may not also set `executable`, and a `local` context may not carry a type block.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A simple, modern alternative to GNU Make. *taskctl* is a concurrent task runner 
 - concurrent task execution with DAG-based pipelines: dependencies, conditions, allowed failures, graph visualization
 - cross-platform: embedded shell interpreter, no dependency on a system shell
 - AI-agent friendly: JSON discovery, NDJSON run events, non-interactive mode, installable agent skill
-- customizable execution contexts (wrap commands in `docker`, `ssh`, any binary)
+- typed execution contexts: run commands in `docker`, `kubernetes` or `ssh` targets, or wrap them in any binary
 - templated commands with variables, task variations, and output piped between tasks
 - integrated file watcher (live reload)
 - output formats: raw, prefixed, live dashboard (`default`), or JSON event stream
@@ -401,14 +401,15 @@ contexts:
 
 A context definition takes the following parameters:
 - `dir` - working directory. Also the base for a relative `env_file` path
-- `executable` - binary (`bin`) and its arguments (`args`) that will run the task's commands
+- `type` - context type: `local` (default), `docker`, `kubernetes` or `ssh`. Type-specific settings go in a nested block named after the type (see [Typed contexts](#typed-contexts))
+- `executable` - binary (`bin`) and its arguments (`args`) that will run the task's commands (the `local` escape hatch; mutually exclusive with a `type` block)
 - `quote` - symbol to quote commands with when passing them to the executable
 - `env` - environment variables
 - `env_file` - file with env variables in `k=v` format to read variables from
 - `variables` - context's variables
 - `up`, `down`, `before`, `after` - lifecycle hooks (see below)
 
-A task that declares no `context:` runs in the context named `default`. Define one to share environment variables, variables, a working directory, executable or lifecycle hooks across every such task — this is how you give all tasks a common `env`. A task's own `env`/`variables` override the default context's (precedence: `default context < task`). Tasks that opt into another context use that one instead; if no `default` context is defined, context-less tasks run in an empty implicit context.
+A task that declares no `context:` runs in the context named `default`. Define one to share environment variables, variables, a working directory, executable or lifecycle hooks across every such task — this is how you give all tasks a common `env`. A task's own `env`/`variables` override the default context's (precedence: `default context < task`). Tasks that opt into another context use that one instead; if no `default` context is defined, context-less tasks run in an empty implicit context. The `default` context may itself be typed, making every context-less task run inside that docker/kubernetes/ssh target.
 
 A context has lifecycle hooks: `up` and `down` run once per taskctl run - `up` before the context's first usage, `down` during cleanup when the run finishes. `before` and `after` run every time around each task that uses the context.
 ```yaml
@@ -424,19 +425,63 @@ context:
       after: rm -rf var/*
 ```
 
-### Docker context
+### Typed contexts
+
+A context's `type:` selects how commands run. The default, `local`, runs them on the host (directly, or through the optional `executable:` escape hatch). `docker`, `kubernetes` and `ssh` run every command — plus the task's `before`/`after`, its `condition`, and the context's own `up`/`down`/`before`/`after` hooks — inside the target. Type-specific settings go in a block named after the type.
+
+For a typed context the task's `env` and `dir` are applied *inside* the target, not on the local launcher: docker forwards them with `-e KEY=VAL`/`-w`, while kubernetes and ssh inline `export KEY=VAL; cd <dir> && <command>` into the remote shell. Only declared `env` is forwarded (including the injected `TASKCTL__ARGS`/`TASKCTL__TASK_NAME`); the host's own environment is not.
+
 ```yaml
+contexts:
+  # docker run mode: a fresh `docker run --rm` container per command
+  api:
+    type: docker
+    dir: /app                     # workdir inside the container
+    env: { NODE_ENV: prod }       # forwarded into the container
+    docker:
+      image: node:20              # run mode; mutually exclusive with `container`
+      host: tcp://0.0.0.0:2375    # optional docker daemon host (docker -H)
+      options: [--network, host]  # extra flags, passed through verbatim
+      shell: [sh, -c]             # in-target shell, default `sh -c`
+
+  # docker exec mode: run against a container you started yourself
+  worker:
+    type: docker
+    docker:
+      container: my-app           # exec mode; mutually exclusive with `image`
+
+  cluster:
+    type: kubernetes
+    kubernetes:
+      pod: web-0                  # required
+      namespace: stage
+      container: app              # optional `-c` container within the pod
+      kube_context: my-ctx        # optional `--context`
+      kubeconfig: /path/to/config # optional `--kubeconfig`
+      shell: [sh, -c]             # in-target shell, default `sh -c`
+
+  box:
+    type: ssh
+    ssh:
+      host: build-01              # required
+      user: deploy
+      port: 2222
+      identity_file: ~/.ssh/id_ed25519
+```
+
+Docker **run mode** (`image:`) starts a fresh `--rm` container for every command, so state does not persist between commands — an `up:` install step won't be visible to later commands. For stateful setup use **exec mode** (`container:`) against a container you start yourself (e.g. from a `local`/escape-hatch `up:` hook or out of band), or use kubernetes/ssh.
+
+Validation: `docker` requires exactly one of `image`/`container`; `kubernetes` requires `pod`; `ssh` requires `host`. A typed context may not also set `executable`, and a `local` context may not carry a type block.
+
+The low-level `executable:` form remains the escape hatch — leave `type` unset (or `local`) and give a `bin`/`args` to wrap commands in any binary yourself:
+```yaml
+contexts:
   alpine:
     executable:
       bin: /usr/local/bin/docker
-      args:
-        - run
-        - --rm
-        - alpine:latest
+      args: [run, --rm, alpine:latest]
     env:
       DOCKER_HOST: "tcp://0.0.0.0:2375"
-    before: echo "SOME COMMAND TO RUN BEFORE TASK"
-    after: echo "SOME COMMAND TO RUN WHEN TASK FINISHED SUCCESSFULLY"
 
 tasks:
   mysql-task:

--- a/docs/example.yaml
+++ b/docs/example.yaml
@@ -171,7 +171,7 @@ contexts:
   kubernetes-context:
     type: kubernetes
     kubernetes:
-      pod: web-0 # required
+      pod: web-0 # required; also accepts a controller ref passed to kubectl exec, e.g. deployment/web
       namespace: stage
       container: app # optional -c container within the pod
       kube_context: my-ctx # optional --context

--- a/docs/example.yaml
+++ b/docs/example.yaml
@@ -43,7 +43,7 @@ tasks:
       VAR_NAME: VAR_VALUE
 
   task4:
-    context: kubectl
+    context: kubernetes-context
     command:
       - echo "I'm task4"
       - env
@@ -124,6 +124,7 @@ contexts:
     before: echo "SOME COMMAND TO RUN BEFORE EVERY TASK"
     after: echo "SOME COMMAND TO RUN WHEN TASK FINISHED SUCCESSFULLY"
 
+  # Escape hatch: wrap commands in any binary via executable.bin/args (type defaults to local)
   docker-context:
     executable:
       bin: /usr/local/bin/docker
@@ -149,15 +150,44 @@ contexts:
     up: docker-compose up -d --build --force-recreate api # Executes once before first context usage
     down: docker-compose down api # Executes once when all tasks done
 
-  kubectl:
-    executable:
-      bin: /usr/local/bin/kubectl
-      args:
-        - exec
-        - -n stage
-        - pod-name
+  # Typed docker context, run mode: a fresh `docker run --rm` container per command
+  docker-run:
+    type: docker
+    dir: /app # workdir inside the container
     env:
-      KUBECONFIG: "$HOME/.kube/alternate-config"
+      NODE_ENV: prod # forwarded into the container via -e
+    docker:
+      image: node:20 # run mode; mutually exclusive with container
+      host: tcp://0.0.0.0:2375 # optional docker daemon host (docker -H)
+      options: [--network, host] # extra flags passed through verbatim
+      shell: [sh, -c] # in-target shell, default sh -c
+
+  # Typed docker context, exec mode: run against a container you started yourself
+  docker-exec:
+    type: docker
+    docker:
+      container: my-app # exec mode; mutually exclusive with image
+
+  kubernetes-context:
+    type: kubernetes
+    kubernetes:
+      pod: web-0 # required
+      namespace: stage
+      container: app # optional -c container within the pod
+      kube_context: my-ctx # optional --context
+      kubeconfig: "$HOME/.kube/alternate-config" # optional --kubeconfig
+      shell: [sh, -c] # in-target shell, default sh -c
+
+  ssh-context:
+    type: ssh
+    dir: /srv/app # remote workdir (cd into it before running)
+    env:
+      DEPLOY_ENV: prod # exported in the remote shell
+    ssh:
+      host: build-01 # required
+      user: deploy
+      port: 2222
+      identity_file: ~/.ssh/id_ed25519
 
 debug: true # debug enabled by default. To temporary disable run with "--debug=false" flag
 dryrun: false # when true, validate task commands (render + parse) without executing them; valid tasks complete as "done". Also settable per-run with "--dry-run"

--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/taskctl/taskctl/internal/envutil"
@@ -20,6 +21,36 @@ type contextDefinition struct {
 	Variables  map[string]string
 	Executable runner.Binary
 	Quote      string
+	Type       string
+	Docker     *dockerDefinition
+	Kubernetes *kubernetesDefinition
+	SSH        *sshDefinition
+}
+
+type dockerDefinition struct {
+	Image     string
+	Container string
+	Host      string
+	Options   []string
+	Shell     []string
+}
+
+type kubernetesDefinition struct {
+	Pod         string
+	Namespace   string
+	Container   string
+	KubeContext string `mapstructure:"kube_context"`
+	Kubeconfig  string
+	Options     []string
+	Shell       []string
+}
+
+type sshDefinition struct {
+	Host         string
+	User         string
+	Port         int
+	IdentityFile string `mapstructure:"identity_file"`
+	Options      []string
 }
 
 func buildContext(def *contextDefinition) (*runner.ExecutionContext, error) {
@@ -43,17 +74,130 @@ func buildContext(def *contextDefinition) (*runner.ExecutionContext, error) {
 		envs = variables.FromMap(fileEnvs).Merge(envs)
 	}
 
+	executable, opts, err := resolveContextType(def)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, runner.WithQuote(def.Quote))
+
 	c := runner.NewExecutionContext(
-		&def.Executable,
+		executable,
 		dir,
 		envs,
 		def.Up,
 		def.Down,
 		def.Before,
 		def.After,
-		runner.WithQuote(def.Quote),
+		opts...,
 	)
 	c.Variables = variables.FromMap(def.Variables)
 
 	return c, nil
+}
+
+// resolveContextType validates def.Type against its nested type-specific blocks
+// and returns the executable (non-nil only for the local/escape-hatch path) and
+// the options needed to build the corresponding wrapper.
+func resolveContextType(def *contextDefinition) (*runner.Binary, []runner.ExecutionContextOption, error) {
+	switch def.Type {
+	case "", "local":
+		if err := checkForeignBlocks(def, def.Type); err != nil {
+			return nil, nil, err
+		}
+
+		return &def.Executable, nil, nil
+	case "docker":
+		if err := checkForeignBlocks(def, "docker"); err != nil {
+			return nil, nil, err
+		}
+		if def.Docker == nil {
+			return nil, nil, fmt.Errorf("context type %q requires a docker block", def.Type)
+		}
+		if err := checkNoExecutable(def); err != nil {
+			return nil, nil, err
+		}
+		if (def.Docker.Image == "") == (def.Docker.Container == "") {
+			return nil, nil, fmt.Errorf("docker context requires exactly one of image or container")
+		}
+
+		spec := runner.DockerSpec{
+			Image:     def.Docker.Image,
+			Container: def.Docker.Container,
+			Host:      def.Docker.Host,
+			Options:   def.Docker.Options,
+			Shell:     def.Docker.Shell,
+		}
+
+		return nil, []runner.ExecutionContextOption{runner.WithDocker(spec)}, nil
+	case "kubernetes":
+		if err := checkForeignBlocks(def, "kubernetes"); err != nil {
+			return nil, nil, err
+		}
+		if def.Kubernetes == nil || def.Kubernetes.Pod == "" {
+			return nil, nil, fmt.Errorf("kubernetes context requires pod")
+		}
+		if err := checkNoExecutable(def); err != nil {
+			return nil, nil, err
+		}
+
+		spec := runner.KubernetesSpec{
+			Pod:         def.Kubernetes.Pod,
+			Namespace:   def.Kubernetes.Namespace,
+			Container:   def.Kubernetes.Container,
+			KubeContext: def.Kubernetes.KubeContext,
+			Kubeconfig:  def.Kubernetes.Kubeconfig,
+			Options:     def.Kubernetes.Options,
+			Shell:       def.Kubernetes.Shell,
+		}
+
+		return nil, []runner.ExecutionContextOption{runner.WithKubernetes(spec)}, nil
+	case "ssh":
+		if err := checkForeignBlocks(def, "ssh"); err != nil {
+			return nil, nil, err
+		}
+		if def.SSH == nil || def.SSH.Host == "" {
+			return nil, nil, fmt.Errorf("ssh context requires host")
+		}
+		if err := checkNoExecutable(def); err != nil {
+			return nil, nil, err
+		}
+
+		spec := runner.SSHSpec{
+			Host:         def.SSH.Host,
+			User:         def.SSH.User,
+			Port:         def.SSH.Port,
+			IdentityFile: def.SSH.IdentityFile,
+			Options:      def.SSH.Options,
+		}
+
+		return nil, []runner.ExecutionContextOption{runner.WithSSH(spec)}, nil
+	default:
+		return nil, nil, fmt.Errorf("unknown context type %q", def.Type)
+	}
+}
+
+// checkForeignBlocks rejects type-specific blocks that don't belong to typ, e.g.
+// a "docker"-typed context that also sets a ssh: block.
+func checkForeignBlocks(def *contextDefinition, typ string) error {
+	if typ != "docker" && def.Docker != nil {
+		return fmt.Errorf("context type %q does not accept a docker block", typ)
+	}
+	if typ != "kubernetes" && def.Kubernetes != nil {
+		return fmt.Errorf("context type %q does not accept a kubernetes block", typ)
+	}
+	if typ != "ssh" && def.SSH != nil {
+		return fmt.Errorf("context type %q does not accept a ssh block", typ)
+	}
+
+	return nil
+}
+
+// checkNoExecutable rejects the escape-hatch executable on typed contexts, since
+// the wrapper drives command execution instead.
+func checkNoExecutable(def *contextDefinition) error {
+	if def.Executable.Bin != "" || len(def.Executable.Args) > 0 {
+		return fmt.Errorf("context type %q does not accept an executable block", def.Type)
+	}
+
+	return nil
 }

--- a/internal/config/context_test.go
+++ b/internal/config/context_test.go
@@ -1,9 +1,13 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/taskctl/taskctl/internal/fsutil"
+	"github.com/taskctl/taskctl/runner"
 	"github.com/taskctl/taskctl/variables"
 )
 
@@ -41,5 +45,127 @@ func Test_buildContext_env_file(t *testing.T) {
 		if c.Env.Get(k) != v {
 			t.Errorf("buildContext() env error, want %s, got %s", v, c.Env.Get(k))
 		}
+	}
+}
+
+func Test_buildContext_typed_contexts_from_config(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cl := NewConfigLoader(NewConfig())
+	cfg, err := cl.Load(filepath.Join(cwd, "testdata", "typed_contexts.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	local := cfg.Contexts["local_ctx"]
+	if local == nil {
+		t.Fatal("local_ctx not found")
+	}
+	if local.Executable == nil {
+		t.Error("local_ctx: expected non-nil Executable")
+	}
+	if local.Dir != "/tmp" {
+		t.Errorf("local_ctx: got dir %q", local.Dir)
+	}
+
+	cases := []string{"docker_run_ctx", "docker_exec_ctx", "kubernetes_ctx", "ssh_ctx"}
+	for _, name := range cases {
+		c := cfg.Contexts[name]
+		if c == nil {
+			t.Fatalf("%s not found", name)
+		}
+		if c.Executable != nil {
+			t.Errorf("%s: expected nil Executable, got %+v", name, c.Executable)
+		}
+	}
+
+	dockerRun := cfg.Contexts["docker_run_ctx"]
+	if dockerRun.Dir != "/tmp" {
+		t.Errorf("docker_run_ctx: got dir %q", dockerRun.Dir)
+	}
+	if dockerRun.Env.Get("FOO") != "bar" {
+		t.Errorf("docker_run_ctx: got env FOO=%q", dockerRun.Env.Get("FOO"))
+	}
+
+	sshCtx := cfg.Contexts["ssh_ctx"]
+	if sshCtx.Dir != "/tmp" {
+		t.Errorf("ssh_ctx: got dir %q", sshCtx.Dir)
+	}
+}
+
+func Test_buildContext_validation_errors(t *testing.T) {
+	tests := []struct {
+		name string
+		def  *contextDefinition
+		want string
+	}{
+		{
+			name: "unknown type",
+			def:  &contextDefinition{Type: "vagrant"},
+			want: "unknown context type",
+		},
+		{
+			name: "docker neither image nor container",
+			def:  &contextDefinition{Type: "docker", Docker: &dockerDefinition{}},
+			want: "exactly one of image or container",
+		},
+		{
+			name: "docker both image and container",
+			def:  &contextDefinition{Type: "docker", Docker: &dockerDefinition{Image: "alpine", Container: "c1"}},
+			want: "exactly one of image or container",
+		},
+		{
+			name: "docker missing block",
+			def:  &contextDefinition{Type: "docker"},
+			want: "requires a docker block",
+		},
+		{
+			name: "kubernetes without pod",
+			def:  &contextDefinition{Type: "kubernetes", Kubernetes: &kubernetesDefinition{}},
+			want: "requires pod",
+		},
+		{
+			name: "ssh without host",
+			def:  &contextDefinition{Type: "ssh", SSH: &sshDefinition{}},
+			want: "requires host",
+		},
+		{
+			name: "typed context also sets executable",
+			def: &contextDefinition{
+				Type:       "docker",
+				Docker:     &dockerDefinition{Image: "alpine"},
+				Executable: runner.Binary{Bin: "bash"},
+			},
+			want: "does not accept an executable block",
+		},
+		{
+			name: "local context sets docker block",
+			def:  &contextDefinition{Docker: &dockerDefinition{Image: "alpine"}},
+			want: "does not accept a docker block",
+		},
+		{
+			name: "docker type also sets ssh block",
+			def: &contextDefinition{
+				Type:   "docker",
+				Docker: &dockerDefinition{Image: "alpine"},
+				SSH:    &sshDefinition{Host: "example.com"},
+			},
+			want: "does not accept a ssh block",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := buildContext(tt.def)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("got error %q, want substring %q", err.Error(), tt.want)
+			}
+		})
 	}
 }

--- a/internal/config/testdata/typed_contexts.yaml
+++ b/internal/config/testdata/typed_contexts.yaml
@@ -1,0 +1,38 @@
+tasks:
+  test-task:
+    command:
+      - echo true
+
+contexts:
+  local_ctx:
+    dir: /tmp
+    env:
+      LOCAL_ENV: LOCAL_ENV_VALUE
+
+  docker_run_ctx:
+    type: docker
+    dir: /tmp
+    env:
+      FOO: bar
+    docker:
+      image: alpine
+
+  docker_exec_ctx:
+    type: docker
+    docker:
+      container: my-container
+
+  kubernetes_ctx:
+    type: kubernetes
+    kubernetes:
+      pod: my-pod
+      namespace: my-namespace
+      kube_context: my-context
+
+  ssh_ctx:
+    type: ssh
+    dir: /tmp
+    ssh:
+      host: example.com
+      user: deploy
+      identity_file: /home/deploy/.ssh/id_rsa

--- a/runner/compiler.go
+++ b/runner/compiler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/taskctl/taskctl/executor"
+	"github.com/taskctl/taskctl/internal/envutil"
 	"github.com/taskctl/taskctl/internal/tmpl"
 	"github.com/taskctl/taskctl/task"
 	"github.com/taskctl/taskctl/variables"
@@ -90,27 +91,34 @@ func (tc *taskCompiler) compileCommand(
 		Vars:    tc.variables.Merge(vars),
 	}
 
-	var c []string
-	if executionCtx.Executable != nil {
-		c = []string{executionCtx.Executable.Bin}
-		c = append(c, executionCtx.Executable.Args...)
-		c = append(c, fmt.Sprintf("%s%s%s", executionCtx.Quote, command, executionCtx.Quote))
-	} else {
-		c = []string{command}
-	}
-
-	j.Command = strings.Join(c, " ")
-
-	var err error
+	var renderedDir string
 	if dir != "" {
-		j.Dir = dir
+		renderedDir = dir
 	} else if executionCtx.Dir != "" {
-		j.Dir = executionCtx.Dir
+		renderedDir = executionCtx.Dir
 	}
 
-	j.Dir, err = tmpl.RenderString(j.Dir, j.Vars.Map())
+	renderedDir, err := tmpl.RenderString(renderedDir, j.Vars.Map())
 	if err != nil {
 		return nil, err
+	}
+
+	if executionCtx.wrapper != nil {
+		j.Command = executionCtx.wrapper.wrap(command, envutil.ConvertToMapOfStrings(env.Map()), renderedDir)
+		j.Env = variables.NewVariables()
+		j.Dir = ""
+	} else {
+		var c []string
+		if executionCtx.Executable != nil {
+			c = []string{executionCtx.Executable.Bin}
+			c = append(c, executionCtx.Executable.Args...)
+			c = append(c, fmt.Sprintf("%s%s%s", executionCtx.Quote, command, executionCtx.Quote))
+		} else {
+			c = []string{command}
+		}
+
+		j.Command = strings.Join(c, " ")
+		j.Dir = renderedDir
 	}
 
 	return j, nil

--- a/runner/compiler_test.go
+++ b/runner/compiler_test.go
@@ -58,6 +58,72 @@ func TestTaskCompiler_CompileCommand(t *testing.T) {
 	}
 }
 
+func TestTaskCompiler_CompileCommand_Typed(t *testing.T) {
+	tc := newTaskCompiler()
+
+	env := variables.FromMap(map[string]string{"FOO": "bar"})
+	dockerContext := NewExecutionContext(nil, "", env, nil, nil, nil, nil, WithDocker(DockerSpec{Image: "alpine"}))
+
+	job, err := tc.compileCommand(
+		"echo hi",
+		dockerContext,
+		"", nil,
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		env,
+		variables.NewVariables(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if job.Command != "docker run --rm -e 'FOO=bar' alpine sh -c 'echo hi'" {
+		t.Errorf("unexpected wrapped command: %s", job.Command)
+	}
+
+	if len(job.Env.Map()) != 0 {
+		t.Error("env should not be applied to the local launcher for typed contexts")
+	}
+
+	if job.Dir != "" {
+		t.Error("dir should not be applied to the local launcher for typed contexts")
+	}
+}
+
+func TestTaskCompiler_CompileCommand_EscapeHatchUnchanged(t *testing.T) {
+	tc := newTaskCompiler()
+
+	env := variables.FromMap(map[string]string{"HOME": "/root"})
+	escapeHatchContext := NewExecutionContext(&shBin, "/tmp", env, nil, nil, nil, nil, WithQuote("'"))
+
+	job, err := tc.compileCommand(
+		"echo hi",
+		escapeHatchContext,
+		"/root", nil,
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		env,
+		variables.NewVariables(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if job.Command != "/bin/sh -c 'echo hi'" {
+		t.Errorf("unexpected command: %s", job.Command)
+	}
+
+	if job.Env.Map()["HOME"] != "/root" {
+		t.Error("env should be applied to the local launcher for escape-hatch contexts")
+	}
+
+	if job.Dir != "/root" {
+		t.Error("dir should be applied to the local launcher for escape-hatch contexts")
+	}
+}
+
 func TestTaskCompiler_CompileTask(t *testing.T) {
 	tc := newTaskCompiler()
 	j, err := tc.compileTask(&task.Task{

--- a/runner/context.go
+++ b/runner/context.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/taskctl/taskctl/executor"
+	"github.com/taskctl/taskctl/internal/envutil"
 
 	"github.com/taskctl/taskctl/variables"
 )
@@ -24,6 +25,8 @@ type ExecutionContext struct {
 	Env        variables.Container
 	Variables  variables.Container
 	Quote      string
+
+	wrapper commandWrapper
 
 	up     []string
 	down   []string
@@ -124,12 +127,17 @@ func (c *ExecutionContext) runServiceCommand(ctx context.Context, command string
 		return err
 	}
 
-	out, err := ex.Execute(ctx, &executor.Job{
-		Command: command,
-		Dir:     c.Dir,
-		Env:     c.Env,
-		Vars:    c.Variables,
-	})
+	job := &executor.Job{Command: command, Dir: c.Dir, Env: c.Env, Vars: c.Variables}
+	if c.wrapper != nil {
+		// Env/dir are forwarded into the target by the wrapper itself, so the
+		// local launcher job must not also apply them.
+		job = &executor.Job{
+			Command: c.wrapper.wrap(command, envutil.ConvertToMapOfStrings(c.Env.Map()), c.Dir),
+			Vars:    c.Variables,
+		}
+	}
+
+	out, err := ex.Execute(ctx, job)
 	if err != nil {
 		if out != nil {
 			slog.Warn(string(out))
@@ -152,5 +160,26 @@ func defaultContext() *ExecutionContext {
 func WithQuote(quote string) ExecutionContextOption {
 	return func(c *ExecutionContext) {
 		c.Quote = quote
+	}
+}
+
+// WithDocker is functional option to run ExecutionContext commands inside a docker container
+func WithDocker(spec DockerSpec) ExecutionContextOption {
+	return func(c *ExecutionContext) {
+		c.wrapper = newDockerWrapper(spec)
+	}
+}
+
+// WithKubernetes is functional option to run ExecutionContext commands inside a kubernetes pod
+func WithKubernetes(spec KubernetesSpec) ExecutionContextOption {
+	return func(c *ExecutionContext) {
+		c.wrapper = newKubectlWrapper(spec)
+	}
+}
+
+// WithSSH is functional option to run ExecutionContext commands on a remote host over ssh
+func WithSSH(spec SSHSpec) ExecutionContextOption {
+	return func(c *ExecutionContext) {
+		c.wrapper = newSSHWrapper(spec)
 	}
 }

--- a/runner/context_test.go
+++ b/runner/context_test.go
@@ -41,3 +41,42 @@ func TestContext(t *testing.T) {
 
 	runner.Finish()
 }
+
+func TestWithDocker(t *testing.T) {
+	c := NewExecutionContext(nil, "", variables.NewVariables(), nil, nil, nil, nil, WithDocker(DockerSpec{Image: "alpine"}))
+	if c.wrapper == nil {
+		t.Fatal("expected wrapper to be set")
+	}
+
+	got := c.wrapper.wrap("echo hi", map[string]string{"FOO": "bar"}, "/app")
+	want := `docker run --rm -e 'FOO=bar' -w /app alpine sh -c 'echo hi'`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWithKubernetes(t *testing.T) {
+	c := NewExecutionContext(nil, "", variables.NewVariables(), nil, nil, nil, nil, WithKubernetes(KubernetesSpec{Pod: "web"}))
+	if c.wrapper == nil {
+		t.Fatal("expected wrapper to be set")
+	}
+
+	got := c.wrapper.wrap("echo hi", map[string]string{"FOO": "bar"}, "/app")
+	want := `kubectl exec web -- sh -c 'export FOO=bar; cd /app && echo hi'`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestWithSSH(t *testing.T) {
+	c := NewExecutionContext(nil, "", variables.NewVariables(), nil, nil, nil, nil, WithSSH(SSHSpec{Host: "example.com", User: "deploy"}))
+	if c.wrapper == nil {
+		t.Fatal("expected wrapper to be set")
+	}
+
+	got := c.wrapper.wrap("echo hi", map[string]string{"FOO": "bar"}, "/app")
+	want := `ssh deploy@example.com 'export FOO=bar; cd /app && echo hi'`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/runner/wrapper.go
+++ b/runner/wrapper.go
@@ -1,0 +1,215 @@
+package runner
+
+import (
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// DockerSpec configures a wrapper that runs commands inside a Docker container.
+type DockerSpec struct {
+	// Image selects run mode (a fresh container per command); Container selects exec mode. Exactly one must be set.
+	Image     string
+	Container string
+	Host      string
+	Options   []string
+	Shell     []string
+}
+
+// KubernetesSpec configures a wrapper that runs commands via kubectl exec.
+type KubernetesSpec struct {
+	Pod         string
+	Namespace   string
+	Container   string
+	KubeContext string
+	Kubeconfig  string
+	Options     []string
+	Shell       []string
+}
+
+// SSHSpec configures a wrapper that runs commands over ssh.
+type SSHSpec struct {
+	Host         string
+	User         string
+	Port         int
+	IdentityFile string
+	Options      []string
+	Shell        []string
+}
+
+// commandWrapper builds the local shell command that executes command inside a target (container, pod, or remote host) with env/dir applied there.
+type commandWrapper interface {
+	wrap(command string, env map[string]string, dir string) string
+}
+
+type dockerWrapper struct {
+	spec DockerSpec
+}
+
+type kubectlWrapper struct {
+	spec KubernetesSpec
+}
+
+type sshWrapper struct {
+	spec SSHSpec
+}
+
+func newDockerWrapper(spec DockerSpec) commandWrapper {
+	if len(spec.Shell) == 0 {
+		spec.Shell = defaultShell()
+	}
+	return &dockerWrapper{spec: spec}
+}
+
+func newKubectlWrapper(spec KubernetesSpec) commandWrapper {
+	if len(spec.Shell) == 0 {
+		spec.Shell = defaultShell()
+	}
+	return &kubectlWrapper{spec: spec}
+}
+
+func newSSHWrapper(spec SSHSpec) commandWrapper {
+	if len(spec.Shell) == 0 {
+		spec.Shell = defaultShell()
+	}
+	return &sshWrapper{spec: spec}
+}
+
+func (w *dockerWrapper) wrap(command string, env map[string]string, dir string) string {
+	tokens := []string{"docker"}
+	if w.spec.Host != "" {
+		tokens = append(tokens, "-H", shellQuote(w.spec.Host))
+	}
+
+	if w.spec.Image != "" {
+		tokens = append(tokens, "run", "--rm")
+	} else {
+		tokens = append(tokens, "exec")
+	}
+
+	tokens = append(tokens, envFlags(env)...)
+
+	if dir != "" {
+		tokens = append(tokens, "-w", shellQuote(dir))
+	}
+
+	tokens = append(tokens, w.spec.Options...)
+
+	if w.spec.Image != "" {
+		tokens = append(tokens, shellQuote(w.spec.Image))
+	} else {
+		tokens = append(tokens, shellQuote(w.spec.Container))
+	}
+
+	tokens = append(tokens, w.spec.Shell...)
+	tokens = append(tokens, shellQuote(command))
+
+	return strings.Join(tokens, " ")
+}
+
+func (w *kubectlWrapper) wrap(command string, env map[string]string, dir string) string {
+	tokens := []string{"kubectl"}
+	if w.spec.Kubeconfig != "" {
+		tokens = append(tokens, "--kubeconfig", shellQuote(w.spec.Kubeconfig))
+	}
+	if w.spec.KubeContext != "" {
+		tokens = append(tokens, "--context", shellQuote(w.spec.KubeContext))
+	}
+	if w.spec.Namespace != "" {
+		tokens = append(tokens, "-n", shellQuote(w.spec.Namespace))
+	}
+
+	tokens = append(tokens, "exec")
+	tokens = append(tokens, w.spec.Options...)
+	tokens = append(tokens, shellQuote(w.spec.Pod))
+
+	if w.spec.Container != "" {
+		tokens = append(tokens, "-c", shellQuote(w.spec.Container))
+	}
+
+	tokens = append(tokens, "--")
+	tokens = append(tokens, w.spec.Shell...)
+	tokens = append(tokens, shellQuote(buildScript(env, dir, command)))
+
+	return strings.Join(tokens, " ")
+}
+
+func (w *sshWrapper) wrap(command string, env map[string]string, dir string) string {
+	tokens := []string{"ssh"}
+	if w.spec.Port != 0 {
+		tokens = append(tokens, "-p", shellQuote(strconv.Itoa(w.spec.Port)))
+	}
+	if w.spec.IdentityFile != "" {
+		tokens = append(tokens, "-i", shellQuote(w.spec.IdentityFile))
+	}
+
+	tokens = append(tokens, w.spec.Options...)
+
+	target := w.spec.Host
+	if w.spec.User != "" {
+		target = w.spec.User + "@" + w.spec.Host
+	}
+	tokens = append(tokens, shellQuote(target))
+	tokens = append(tokens, shellQuote(buildScript(env, dir, command)))
+
+	return strings.Join(tokens, " ")
+}
+
+// shellQuote POSIX-quotes s for the local shell parse; it is the single choke point for local-parse quoting.
+func shellQuote(s string) string {
+	quoted, err := syntax.Quote(s, syntax.LangPOSIX)
+	if err != nil {
+		return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+	}
+	return quoted
+}
+
+// buildScript builds the in-target script that exports env, cds into dir, then runs command.
+func buildScript(env map[string]string, dir, command string) string {
+	var b strings.Builder
+
+	if len(env) > 0 {
+		b.WriteString("export ")
+		keys := slices.Sorted(maps.Keys(env))
+		for i, k := range keys {
+			if i > 0 {
+				b.WriteString(" ")
+			}
+			b.WriteString(k)
+			b.WriteString("=")
+			b.WriteString(shellQuote(env[k]))
+		}
+		b.WriteString("; ")
+	}
+
+	if dir != "" {
+		b.WriteString("cd ")
+		b.WriteString(shellQuote(dir))
+		b.WriteString(" && ")
+	}
+
+	b.WriteString(command)
+
+	return b.String()
+}
+
+// envFlags returns docker -e flags for env, one pair of tokens per sorted key.
+func envFlags(env map[string]string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+
+	keys := slices.Sorted(maps.Keys(env))
+	flags := make([]string, 0, len(keys)*2)
+	for _, k := range keys {
+		flags = append(flags, "-e", shellQuote(k+"="+env[k]))
+	}
+	return flags
+}
+
+func defaultShell() []string {
+	return []string{"sh", "-c"}
+}

--- a/runner/wrapper_test.go
+++ b/runner/wrapper_test.go
@@ -1,0 +1,167 @@
+package runner
+
+import "testing"
+
+func TestDockerWrapperWrap(t *testing.T) {
+	tt := []struct {
+		name    string
+		spec    DockerSpec
+		command string
+		env     map[string]string
+		dir     string
+		want    string
+	}{
+		{
+			name:    "run no env no dir",
+			spec:    DockerSpec{Image: "alpine"},
+			command: "echo hi",
+			want:    "docker run --rm alpine sh -c 'echo hi'",
+		},
+		{
+			name:    "run with env and dir",
+			spec:    DockerSpec{Image: "alpine"},
+			command: "echo hi",
+			env:     map[string]string{"FOO": "bar baz", "QUOTE": "it's"},
+			dir:     "/app",
+			want:    `docker run --rm -e 'FOO=bar baz' -e "QUOTE=it's" -w /app alpine sh -c 'echo hi'`,
+		},
+		{
+			name:    "run with host",
+			spec:    DockerSpec{Image: "alpine", Host: "tcp://1.2.3.4:2375"},
+			command: "echo hi",
+			want:    "docker -H tcp://1.2.3.4:2375 run --rm alpine sh -c 'echo hi'",
+		},
+		{
+			name:    "run with options",
+			spec:    DockerSpec{Image: "alpine", Options: []string{"--network", "host"}},
+			command: "echo hi",
+			want:    "docker run --rm --network host alpine sh -c 'echo hi'",
+		},
+		{
+			name:    "run with custom shell",
+			spec:    DockerSpec{Image: "alpine", Shell: []string{"bash", "-lc"}},
+			command: "echo hi",
+			want:    "docker run --rm alpine bash -lc 'echo hi'",
+		},
+		{
+			name:    "exec with container env and dir",
+			spec:    DockerSpec{Container: "mycontainer"},
+			command: "echo hi",
+			env:     map[string]string{"FOO": "bar"},
+			dir:     "/app",
+			want:    "docker exec -e 'FOO=bar' -w /app mycontainer sh -c 'echo hi'",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			w := newDockerWrapper(tc.spec)
+			got := w.wrap(tc.command, tc.env, tc.dir)
+			if got != tc.want {
+				t.Errorf("wrap() =\n  %q\nwant\n  %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestKubectlWrapperWrap(t *testing.T) {
+	tt := []struct {
+		name    string
+		spec    KubernetesSpec
+		command string
+		env     map[string]string
+		dir     string
+		want    string
+	}{
+		{
+			name:    "pod only",
+			spec:    KubernetesSpec{Pod: "mypod"},
+			command: "echo hi",
+			want:    "kubectl exec mypod -- sh -c 'echo hi'",
+		},
+		{
+			name: "namespace container kubeconfig context",
+			spec: KubernetesSpec{
+				Pod:         "mypod",
+				Namespace:   "myns",
+				Container:   "mycontainer",
+				KubeContext: "mycluster",
+				Kubeconfig:  "/path/to/kubeconfig",
+			},
+			command: "echo hi",
+			want:    "kubectl --kubeconfig /path/to/kubeconfig --context mycluster -n myns exec mypod -c mycontainer -- sh -c 'echo hi'",
+		},
+		{
+			name:    "with env and dir",
+			spec:    KubernetesSpec{Pod: "mypod"},
+			command: "echo hi",
+			env:     map[string]string{"FOO": "bar baz", "QUOTE": "it's"},
+			dir:     "/app",
+			want:    `kubectl exec mypod -- sh -c "export FOO='bar baz' QUOTE=\"it's\"; cd /app && echo hi"`,
+		},
+		{
+			name:    "with options",
+			spec:    KubernetesSpec{Pod: "mypod", Options: []string{"--request-timeout", "30s"}},
+			command: "echo hi",
+			want:    "kubectl exec --request-timeout 30s mypod -- sh -c 'echo hi'",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			w := newKubectlWrapper(tc.spec)
+			got := w.wrap(tc.command, tc.env, tc.dir)
+			if got != tc.want {
+				t.Errorf("wrap() =\n  %q\nwant\n  %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSSHWrapperWrap(t *testing.T) {
+	tt := []struct {
+		name    string
+		spec    SSHSpec
+		command string
+		env     map[string]string
+		dir     string
+		want    string
+	}{
+		{
+			name:    "host only",
+			spec:    SSHSpec{Host: "example.com"},
+			command: "echo hi",
+			want:    "ssh example.com 'echo hi'",
+		},
+		{
+			name:    "user@host",
+			spec:    SSHSpec{Host: "example.com", User: "deploy"},
+			command: "echo hi",
+			want:    "ssh deploy@example.com 'echo hi'",
+		},
+		{
+			name:    "with port identity and options",
+			spec:    SSHSpec{Host: "example.com", Port: 2222, IdentityFile: "/home/me/.ssh/id_rsa", Options: []string{"-o", "StrictHostKeyChecking=no"}},
+			command: "echo hi",
+			want:    "ssh -p 2222 -i /home/me/.ssh/id_rsa -o StrictHostKeyChecking=no example.com 'echo hi'",
+		},
+		{
+			name:    "with env and dir",
+			spec:    SSHSpec{Host: "example.com"},
+			command: "echo hi",
+			env:     map[string]string{"FOO": "bar baz", "QUOTE": "it's"},
+			dir:     "/app",
+			want:    `ssh example.com "export FOO='bar baz' QUOTE=\"it's\"; cd /app && echo hi"`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			w := newSSHWrapper(tc.spec)
+			got := w.wrap(tc.command, tc.env, tc.dir)
+			if got != tc.want {
+				t.Errorf("wrap() =\n  %q\nwant\n  %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Contexts gain a `type:` discriminator — `local` (default), `docker`, `kubernetes`, or `ssh` — so tasks can run inside a container, pod, or remote host declaratively, instead of hand-assembling a `docker run …` / `kubectl exec …` / `ssh …` invocation via the low-level `executable: {bin, args}` field. Type-specific settings live in a nested block named after the type.

```yaml
contexts:
  api:
    type: docker
    dir: /app                    # workdir inside the container
    env: { NODE_ENV: prod }      # forwarded into the container (-e)
    docker:
      image: node:20             # run mode  (mutually exclusive with `container`)
      options: [--network, host]
  cluster:
    type: kubernetes
    kubernetes: { pod: web-0, namespace: stage, container: app }
  box:
    type: ssh
    ssh: { host: build-01, user: deploy, port: 2222, identity_file: ~/.ssh/id_ed25519 }
```

## Goal

The generic `executable:` escape hatch works but is verbose, unvalidated, and easy to get wrong (exact flag order, quoting). Typed contexts give the common docker/kubernetes/ssh targets first-class, validated fields while keeping the same underlying execution model.

## Decisions

- **Env & dir cross the boundary.** For a typed context the task's *declared* env and `dir` are applied **inside** the target — docker via `-e KEY=VAL`/`-w`, kubernetes and ssh by inlining `export KEY=VAL; cd <dir> && <command>`. Only declared env is forwarded (incl. the injected `TASKCTL__ARGS`/`TASKCTL__TASK_NAME`); the host's own `os.Environ` is not.
- **Everything runs on-target.** Not just task commands, but the task's `before`/`after`, its `condition`, and the context's own `up`/`down`/`before`/`after` hooks all run inside the target for a typed context.
- **Docker run vs exec.** `image:` → `docker run --rm` (fresh container per command); `container:` → `docker exec` (a container you started yourself). Exactly one is required. Run mode is ephemeral, so state does not persist between commands — documented; use exec/kubernetes/ssh for stateful setup.
- **Backward compatible.** `type` is optional and defaults to `local`; the `executable:` form is unchanged and remains the escape hatch. Existing configs are byte-for-byte unaffected. A typed context may not also set `executable`; validation requires docker=exactly one of image/container, kubernetes=pod, ssh=host.
- The `default` context may itself be typed, making every context-less task run in that target.

## Architecture

One structural seam does the work: `ExecutionContext` gains a single unexported `wrapper` field.

- **`runner/wrapper.go` (new)** — a `commandWrapper` interface plus `dockerWrapper`/`kubectlWrapper`/`sshWrapper`, pure command-string builders. Exported `DockerSpec`/`KubernetesSpec`/`SSHSpec` + `WithDocker`/`WithKubernetes`/`WithSSH` options are the only additions to the public API. All injected tokens are POSIX-quoted through a single `syntax.Quote` choke point; env ordering is deterministic (sorted keys).
- **`runner/compiler.go` / `runner/context.go`** — when `wrapper != nil`, task commands and lifecycle hooks are wrapped and env/dir are emptied on the local launcher (forwarded into the target instead). When nil (local/escape-hatch), the existing code paths are untouched.
- **`internal/config/context.go`** — decodes `type:` + the nested blocks and compiles them into the wrapper options, with validation.

Command execution itself is unchanged: the wrapped string is still parsed and run by the embedded `mvdan.cc/sh` interpreter locally — the wrapper just prefixes the transport (`docker`/`kubectl`/`ssh`).

## Tests

Exhaustive white-box wrapper output tests (`runner/wrapper_test.go`) are the correctness net since real docker/ssh can't run in CI; plus compiler, context-wiring, and config decode/validation tests. Full suite: `go test -race ./...` → 212 passing across 18 packages; `golangci-lint` clean; every typed context also validated end-to-end via `--dry-run` (render + shell-parse of the wrapped command).